### PR TITLE
Put named values before global policy

### DIFF
--- a/tools/code/publisher/Publisher.cs
+++ b/tools/code/publisher/Publisher.cs
@@ -239,9 +239,9 @@ internal class Publisher : BackgroundService
         }
 
         await PutServiceInformationFile(serviceInformationFiles, cancellationToken);
+        await PutNamedValueInformationFiles(namedValueInformationFiles, cancellationToken);
         await PutServicePolicyFile(servicePolicyFiles, cancellationToken);
         await PutLoggerInformationFiles(loggerInformationFiles, cancellationToken);
-        await PutNamedValueInformationFiles(namedValueInformationFiles, cancellationToken);
         await PutDiagnosticInformationFiles(diagnosticInformationFiles, cancellationToken);
         await PutGatewayInformationFiles(gatewayInformationFiles, cancellationToken);
         await PutProductInformationFiles(productInformationFiles, cancellationToken);


### PR DESCRIPTION
Fixed a bug where utilizing a namevalue property in a global policy would cause the publisher to fail.