### PR TITLE
Adding Version Set support and nested api version & revision files

### DIFF
--- a/configuration.prod.yaml
+++ b/configuration.prod.yaml
@@ -17,7 +17,7 @@ diagnostics:
    - name: applicationinsights
      verbosity: Error
 apis:
-  - name: "[target api to apply application insights to]"
+  - name: "[target api version & revision to apply application insights to e.g. 'my-api', 'my-api-v2', 'my-api-v2;rev=2']"
     diagnostics:
       - name: applicationinsights
         verbosity: Error

--- a/tools/code/common/ApiVersionSet.cs
+++ b/tools/code/common/ApiVersionSet.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+
+namespace common;
+public sealed record ApiVersionSetId : NonEmptyString
+{
+    private ApiVersionSetId(string value) : base(value)
+    {
+    }
+
+    public static ApiVersionSetId From(string value) => new(value);
+}
+
+public sealed record ApiVersionSetDirectory : DirectoryRecord
+{
+    public ApisDirectory ApisDirectory { get; }
+    public ApiDisplayName ApiDisplayName { get; }
+
+    private ApiVersionSetDirectory(ApisDirectory apisDirectory, ApiDisplayName apiDisplayName) : base(apisDirectory.Path.Append(apiDisplayName))
+    {
+        ApisDirectory = apisDirectory;
+        ApiDisplayName = apiDisplayName;
+    }
+
+    public static ApiVersionSetDirectory From(ApisDirectory apisDirectory, ApiDisplayName apiDisplayName) => new(apisDirectory, apiDisplayName);
+
+    public static ApiVersionSetDirectory? TryFrom(ServiceDirectory serviceDirectory, DirectoryInfo? directory)
+    {
+        // apis/<api-name>
+        var parentDirectory = directory?.Parent;
+        if (parentDirectory is not null)
+        {
+            var apisDirectory = ApisDirectory.TryFrom(serviceDirectory, parentDirectory);
+
+            return apisDirectory is null ? null : From(apisDirectory, ApiDisplayName.From(directory!.Name));
+        }
+        else
+        {
+            return null;
+        }
+    }
+}
+
+
+public sealed record ApiVersionSetInformationFile : FileRecord
+{
+    private static readonly string name = "apiVersionSet.json";
+
+    public ApiVersionSetDirectory VersionSetDirectory { get; }
+
+    private ApiVersionSetInformationFile(ApiVersionSetDirectory versionSetDirectory) : base(versionSetDirectory.Path.Append(name))
+    {
+        VersionSetDirectory = versionSetDirectory;
+    }
+
+    public static ApiVersionSetInformationFile From(ApiVersionSetDirectory versionSetDirectory) => new(versionSetDirectory);
+
+    public static ApiVersionSetInformationFile? TryFrom(ServiceDirectory serviceDirectory, FileInfo file)
+    {
+        if (name.Equals(file.Name))
+        {
+            var apiDirectory = ApiVersionSetDirectory.TryFrom(serviceDirectory, file.Directory);
+
+            return apiDirectory is null ? null : new(apiDirectory);
+        }
+        else
+        {
+            return null;
+        }
+    }
+}
+
+public static class ApiVersionSet
+{
+    private static readonly JsonSerializerOptions serializerOptions = new() { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
+
+    internal static Uri GetUri(ServiceProviderUri serviceProviderUri, ServiceName serviceName, ApiVersionSetId versionSetId) =>
+        Service.GetUri(serviceProviderUri, serviceName)
+               .AppendPath("apiVersionSets")
+               .AppendPath(versionSetId);
+
+    internal static Uri ListUri(ServiceProviderUri serviceProviderUri, ServiceName serviceName) =>
+        Service.GetUri(serviceProviderUri, serviceName)
+               .AppendPath("apiVersionSets");
+
+    public static ApiVersionSetId GetIdFromFile(ApiVersionSetInformationFile file)
+    {
+        var jsonObject = file.ReadAsJsonObject();
+        var api = Deserialize(jsonObject);
+
+        return ApiVersionSetId.From(api.Name);
+    }
+    public static Models.ApiVersionSet Deserialize(JsonObject jsonObject) =>
+        JsonSerializer.Deserialize<Models.ApiVersionSet>(jsonObject, serializerOptions) ?? throw new InvalidOperationException("Cannot deserialize JSON.");
+
+    public static JsonObject Serialize(Models.ApiVersionSet api) =>
+        JsonSerializer.SerializeToNode(api, serializerOptions)?.AsObject() ?? throw new InvalidOperationException("Cannot serialize to JSON.");
+
+    public static async ValueTask<Models.ApiVersionSet> Get(Func<Uri, CancellationToken, ValueTask<JsonObject>> getResource, ServiceProviderUri serviceProviderUri, ServiceName serviceName, ApiVersionSetId versionSetId, CancellationToken cancellationToken)
+    {
+        var uri = GetUri(serviceProviderUri, serviceName, versionSetId);
+        var json = await getResource(uri, cancellationToken);
+        return Deserialize(json);
+    }
+
+    public static IAsyncEnumerable<Models.ApiVersionSet> List(Func<Uri, CancellationToken, IAsyncEnumerable<JsonObject>> getResources, ServiceProviderUri serviceProviderUri, ServiceName serviceName, CancellationToken cancellationToken)
+    {
+        var uri = ListUri(serviceProviderUri, serviceName);
+        return getResources(uri, cancellationToken).Select(Deserialize);
+    }
+
+    public static async ValueTask Put(Func<Uri, JsonObject, CancellationToken, ValueTask> putResource, ServiceProviderUri serviceProviderUri, ServiceName serviceName, Models.ApiVersionSet apiVersionSet, CancellationToken cancellationToken)
+    {
+        var versionSetId = ApiVersionSetId.From(apiVersionSet.Name);
+        var uri = GetUri(serviceProviderUri, serviceName, versionSetId);
+        var json = Serialize(apiVersionSet);
+        await putResource(uri, json, cancellationToken);
+    }
+
+    public static async ValueTask Delete(Func<Uri, CancellationToken, ValueTask> deleteResource, ServiceProviderUri serviceProviderUri, ServiceName serviceName, ApiVersionSetId versionSetId, CancellationToken cancellationToken)
+    {
+        var uri = GetUri(serviceProviderUri, serviceName, versionSetId);
+        await deleteResource(uri, cancellationToken);
+    }
+}

--- a/tools/code/common/Models/ApiVersionSet.cs
+++ b/tools/code/common/Models/ApiVersionSet.cs
@@ -1,0 +1,21 @@
+﻿using System.Text.Json.Serialization;
+
+namespace common.Models;
+
+public sealed record ApiVersionSet([property: JsonPropertyName("name")] string Name,
+                         [property: JsonPropertyName("properties")] ApiVersionSet.ApiVersionSetCreateOrUpdateProperties Properties)
+{
+    public sealed record ApiVersionSetCreateOrUpdateProperties([property: JsonPropertyName("versioningScheme")] string VersioningScheme,
+                                                     [property: JsonPropertyName("displayName")] string DisplayName)
+    {
+        [JsonPropertyName("description")]
+        public string? Description { get; init; }
+
+        [JsonPropertyName("versionHeaderName")]
+        public string? VersionHeaderName { get; init; }
+
+        [JsonPropertyName("versionQueryName")]
+        public string? VersionQueryName { get; init; }
+
+    }
+}

--- a/tools/code/extractor/Extractor.cs
+++ b/tools/code/extractor/Extractor.cs
@@ -95,6 +95,7 @@ internal class Extractor : BackgroundService
         await ExportLoggers(cancellationToken);
         await ExportProducts(cancellationToken);
         await ExportApis(cancellationToken);
+        await ExportVersionSets(cancellationToken);
         await ExportDiagnostics(cancellationToken);
     }
 
@@ -308,6 +309,28 @@ internal class Extractor : BackgroundService
         await file.OverwriteWithJson(json, cancellationToken);
     }
 
+    private async ValueTask ExportVersionSets(CancellationToken cancellationToken)
+    {
+        var versionSets = ApiVersionSet.List(getResources, serviceProviderUri, serviceName, cancellationToken);
+
+        await Parallel.ForEachAsync(versionSets, cancellationToken, ExportVersionSet);
+    }
+
+    private async ValueTask ExportVersionSet(common.Models.ApiVersionSet apiVersionSet, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Exporting information for version set {versionSetName}...", apiVersionSet.Name);
+
+        var apisDirectory = ApisDirectory.From(serviceDirectory);
+        var apiDisplayName = ApiDisplayName.From(apiVersionSet.Properties.DisplayName);
+
+        var apiDirectory = ApiVersionSetDirectory.From(apisDirectory, apiDisplayName);
+
+        var file = ApiVersionSetInformationFile.From(apiDirectory);
+        var json = ApiVersionSet.Serialize(apiVersionSet);
+
+        await file.OverwriteWithJson(json, cancellationToken);
+    }
+
     private async ValueTask ExportApis(CancellationToken cancellationToken)
     {
         var apis = Api.List(getResources, serviceProviderUri, serviceName, cancellationToken);
@@ -330,7 +353,10 @@ internal class Extractor : BackgroundService
 
         var apisDirectory = ApisDirectory.From(serviceDirectory);
         var apiDisplayName = ApiDisplayName.From(api.Properties.DisplayName);
-        var apiDirectory = ApiDirectory.From(apisDirectory, apiDisplayName);
+        var apiVersion = ApiVersion.From(api.Properties.ApiVersion);
+        var apiRevision = ApiRevision.From(api.Properties.ApiRevision);
+
+        var apiDirectory = ApiDirectory.From(apisDirectory, apiDisplayName, apiVersion, apiRevision);
         var file = ApiInformationFile.From(apiDirectory);
         var json = Api.Serialize(api);
 
@@ -348,7 +374,9 @@ internal class Extractor : BackgroundService
 
             var apisDirectory = ApisDirectory.From(serviceDirectory);
             var apiDisplayName = ApiDisplayName.From(api.Properties.DisplayName);
-            var apiDirectory = ApiDirectory.From(apisDirectory, apiDisplayName);
+            var apiVersion = ApiVersion.From(api.Properties.ApiVersion);
+            var apiRevision = ApiRevision.From(api.Properties.ApiRevision);
+            var apiDirectory = ApiDirectory.From(apisDirectory, apiDisplayName, apiVersion, apiRevision);
             var file = ApiPolicyFile.From(apiDirectory);
 
             await file.OverwriteWithText(policyText, cancellationToken);
@@ -361,7 +389,9 @@ internal class Extractor : BackgroundService
 
         var apisDirectory = ApisDirectory.From(serviceDirectory);
         var apiDisplayName = ApiDisplayName.From(api.Properties.DisplayName);
-        var apiDirectory = ApiDirectory.From(apisDirectory, apiDisplayName);
+        var apiVersion = ApiVersion.From(api.Properties.ApiVersion);
+        var apiRevision = ApiRevision.From(api.Properties.ApiRevision);
+        var apiDirectory = ApiDirectory.From(apisDirectory, apiDisplayName, apiVersion, apiRevision);
         var file = ApiSpecificationFile.From(apiDirectory, specificationFormat);
 
         var apiName = ApiName.From(api.Name);
@@ -386,7 +416,9 @@ internal class Extractor : BackgroundService
 
         var apisDirectory = ApisDirectory.From(serviceDirectory);
         var apiDisplayName = ApiDisplayName.From(api.Properties.DisplayName);
-        var apiDirectory = ApiDirectory.From(apisDirectory, apiDisplayName);
+        var apiVersion = ApiVersion.From(api.Properties.ApiVersion);
+        var apiRevision = ApiRevision.From(api.Properties.ApiRevision);
+        var apiDirectory = ApiDirectory.From(apisDirectory, apiDisplayName, apiVersion, apiRevision);
         var apiDiagnosticsDirectory = ApiDiagnosticsDirectory.From(apiDirectory);
         var apiDiagnosticName = ApiDiagnosticName.From(diagnostic.Name); ;
         var apiDiagnosticDirectory = ApiDiagnosticDirectory.From(apiDiagnosticsDirectory, apiDiagnosticName);
@@ -423,7 +455,9 @@ internal class Extractor : BackgroundService
 
             var apisDirectory = ApisDirectory.From(serviceDirectory);
             var apiDisplayName = ApiDisplayName.From(api.Properties.DisplayName);
-            var apiDirectory = ApiDirectory.From(apisDirectory, apiDisplayName);
+            var apiVersion = ApiVersion.From(api.Properties.ApiVersion);
+            var apiRevision = ApiRevision.From(api.Properties.ApiRevision);
+            var apiDirectory = ApiDirectory.From(apisDirectory, apiDisplayName, apiVersion, apiRevision);
             var apiOperationsDirectory = ApiOperationsDirectory.From(apiDirectory);
             var apiOperationDisplayName = ApiOperationDisplayName.From(apiOperation.Properties.DisplayName);
             var apiOperationDirectory = ApiOperationDirectory.From(apiOperationsDirectory, apiOperationDisplayName);

--- a/tools/code/publisher/Publisher.cs
+++ b/tools/code/publisher/Publisher.cs
@@ -242,7 +242,7 @@ internal class Publisher : BackgroundService
                 default: break;
             }
         }
-        logger.LogInformation($"Found {apiVersionSetInformationFiles.Count} version set files");
+
         await PutServiceInformationFile(serviceInformationFiles, cancellationToken);
         await PutNamedValueInformationFiles(namedValueInformationFiles, cancellationToken);
         await PutServicePolicyFile(servicePolicyFiles, cancellationToken);


### PR DESCRIPTION
- Nested API files by version (default version is "Original") and revision (default revision is 1) to avoid overwriting revision & version files.
![image](https://user-images.githubusercontent.com/99688332/166817839-08400c68-c7de-48eb-92e4-e75c292180db.png)

- Added creation & deletion of VersionSets via a new `apiVersionSet.json` file.

Signed-off-by: Colin McCullough <cmccullough@microsoft.com>