### PR TITLE
Allow Configuration overrides to set the LoggerId of the root APIM diagnostics

### DIFF
--- a/tools/code/publisher/ConfigurationModel.cs
+++ b/tools/code/publisher/ConfigurationModel.cs
@@ -67,6 +67,7 @@ internal record ConfigurationModel
     public record Diagnostic
     {
         public string? Name { get; init; }
+        public string? LoggerId { get; init; }
         public string? Verbosity { get; init; }
     };
 

--- a/tools/code/publisher/Publisher.cs
+++ b/tools/code/publisher/Publisher.cs
@@ -521,6 +521,7 @@ internal class Publisher : BackgroundService
             {
                 Properties = diagnostic.Properties with
                 {
+                    LoggerId = configurationDiagnostic.LoggerId ?? diagnostic.Properties.LoggerId,
                     Verbosity = configurationDiagnostic.Verbosity ?? diagnostic.Properties.Verbosity
                 }
             };


### PR DESCRIPTION
API Diagnostics allow referencing the loggerId, but the root Diagnostics did not. This adds that functionality
Signed-off-by: Colin McCullough <cmccullough@microsoft.com>