### PR TITLE
Feature Support extracting and publishing GraphQL API's

### DIFF
--- a/tools/code/common/Api.cs
+++ b/tools/code/common/Api.cs
@@ -132,7 +132,11 @@ public sealed record ApiInformationFile : FileRecord
 
 public static class Api
 {
-    private static readonly JsonSerializerOptions serializerOptions = new() { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
+    private static readonly JsonSerializerOptions serializerOptions = new() 
+    { 
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
 
     internal static Uri GetUri(ServiceProviderUri serviceProviderUri, ServiceName serviceName, ApiName apiName) =>
         Service.GetUri(serviceProviderUri, serviceName)

--- a/tools/code/common/ApiSchema.cs
+++ b/tools/code/common/ApiSchema.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.IO;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace common;
+
+public sealed record GraphQLSchemaFile : FileRecord
+{
+    public ApiDirectory ApiDirectory { get; }
+    public const string FileName = "schema.graphql";
+
+    private GraphQLSchemaFile(ApiDirectory apiDirectory)
+        : base(apiDirectory.Path.Append(FileName))
+    {
+        ApiDirectory = apiDirectory;
+    }
+
+    public static GraphQLSchemaFile From(ApiDirectory apiDirectory) => new(apiDirectory);
+    
+    public static GraphQLSchemaFile? TryFrom(ServiceDirectory serviceDirectory, FileInfo file)
+    {
+        var apiDirectory = ApiDirectory.TryFrom(serviceDirectory, file.Directory);
+
+        return (apiDirectory, file.Name) switch
+        {
+            (not null, FileName) => new GraphQLSchemaFile(apiDirectory),
+            _ => null
+        };
+    }
+}
+
+public sealed record ApiSchemaName : NonEmptyString
+{
+    private ApiSchemaName(string value) : base(value)
+    {
+    }
+
+    public static ApiSchemaName From(string value) => new(value);
+
+    public static ApiSchemaName GraphQLSchemaName() => new("graphql");
+}
+
+
+public static class ApiSchema
+{
+
+    internal static Uri GetUri(ServiceProviderUri serviceProviderUri, ServiceName serviceName, ApiName apiName, ApiSchemaName schemaName)
+    {
+        return Api.GetUri(serviceProviderUri, serviceName, apiName)
+           .AppendPath("schemas")
+           .AppendPath(schemaName);
+    }
+
+    public static async ValueTask<string?> TryGetGraphQLSchemaContent(Func<Uri, CancellationToken, ValueTask<JsonObject?>> tryGetResource, ServiceProviderUri serviceProviderUri, ServiceName serviceName, ApiName apiName, CancellationToken cancellationToken)
+    {
+        var uri = GetUri(serviceProviderUri,
+                         serviceName,
+                         apiName,
+                         ApiSchemaName.GraphQLSchemaName());
+
+        var json = await tryGetResource(uri, cancellationToken);
+
+        return json?.GetJsonObjectProperty("properties")
+                    .GetJsonObjectProperty("document")
+                    .GetStringProperty("value");
+    }
+
+    public static async ValueTask PutGraphQL(Func<Uri, JsonObject, CancellationToken, ValueTask> putResource, ServiceProviderUri serviceProviderUri, ServiceName serviceName, ApiName apiName, string schemaText, CancellationToken cancellationToken)
+    {
+        var json = new JsonObject()
+        {
+            ["name"] = ApiSchemaName.GraphQLSchemaName().ToString(),
+            ["properties"] = new JsonObject
+            {
+                ["contentType"] = "application/vnd.ms-azure-apim.graphql.schema",
+                ["value"] = schemaText
+            }
+        };
+
+        var uri = GetUri(serviceProviderUri, serviceName, apiName, ApiSchemaName.GraphQLSchemaName());
+        await putResource(uri, json, cancellationToken);
+    }
+}

--- a/tools/code/common/ApiSchema.cs
+++ b/tools/code/common/ApiSchema.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
@@ -71,11 +72,13 @@ public static class ApiSchema
     {
         var json = new JsonObject()
         {
-            ["name"] = ApiSchemaName.GraphQLSchemaName().ToString(),
             ["properties"] = new JsonObject
             {
                 ["contentType"] = "application/vnd.ms-azure-apim.graphql.schema",
-                ["value"] = schemaText
+                ["document"] = new JsonObject() 
+                {
+                    ["value"] = schemaText
+                }
             }
         };
 

--- a/tools/code/common/Models/Api.cs
+++ b/tools/code/common/Models/Api.cs
@@ -66,7 +66,7 @@ public sealed record Api([property: JsonPropertyName("name")] string Name,
         public string? TermsOfServiceUrl { get; init; }
 
         [JsonPropertyName("type")]
-        public string? Type { get; init; }
+        public ApiType? Type { get; init; }
 
         [JsonPropertyName("value")]
         public string? Value { get; init; }
@@ -161,4 +161,11 @@ public sealed record Api([property: JsonPropertyName("name")] string Name,
         [JsonPropertyName("wsdlServiceName")]
         public string? WsdlServiceName { get; init; }
     }
+}
+public enum ApiType
+{
+    Graphql,
+    Http,
+    Soap,
+    Websocket
 }

--- a/tools/code/common/Models/ApiSchema.cs
+++ b/tools/code/common/Models/ApiSchema.cs
@@ -1,0 +1,7 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace common.Models;

--- a/tools/code/publisher/Publisher.cs
+++ b/tools/code/publisher/Publisher.cs
@@ -322,6 +322,7 @@ internal class Publisher : BackgroundService
         var apiVersionSetInformationFiles = files.Choose(file => file as ApiVersionSetInformationFile).ToList();
         var apiInformationFiles = files.Choose(file => file as ApiInformationFile).ToList();
         var apiSpecificationFiles = files.Choose(file => file as ApiSpecificationFile).ToList();
+        var apiGraphQLFiles = files.Choose(file => file as GraphQLSchemaFile).ToList();
         var apiDiagnosticInformationFiles = files.Choose(file => file as ApiDiagnosticInformationFile).ToList();
         var apiPolicyFiles = files.Choose(file => file as ApiPolicyFile).ToList();
         var apiOperationPolicyFiles = files.Choose(file => file as ApiOperationPolicyFile).ToList();
@@ -359,6 +360,7 @@ internal class Publisher : BackgroundService
         ?? DiagnosticInformationFile.TryFrom(serviceDirectory, file) as FileRecord
         ?? ApiVersionSetInformationFile.TryFrom(serviceDirectory, file) as FileRecord
         ?? ApiInformationFile.TryFrom(serviceDirectory, file) as FileRecord
+        ?? GraphQLSchemaFile.TryFrom(serviceDirectory, file) as FileRecord
         ?? ApiSpecificationFile.TryFrom(serviceDirectory, file) as FileRecord
         ?? ApiDiagnosticInformationFile.TryFrom(serviceDirectory, file) as FileRecord
         ?? ApiPolicyFile.TryFrom(serviceDirectory, file) as FileRecord

--- a/tools/code/publisher/Publisher.cs
+++ b/tools/code/publisher/Publisher.cs
@@ -327,17 +327,17 @@ internal class Publisher : BackgroundService
         var apiPolicyFiles = files.Choose(file => file as ApiPolicyFile).ToList();
         var apiOperationPolicyFiles = files.Choose(file => file as ApiOperationPolicyFile).ToList();
 
-        //await PutNamedValueInformationFiles(namedValueInformationFiles, cancellationToken);
-        //await PutPolicyFragments(policyFragmentInformationFiles, policyFragmentPolicyFiles, cancellationToken);
-        //await PutServicePolicyFile(servicePolicyFiles, cancellationToken);
-        //await PutLoggerInformationFiles(loggerInformationFiles, cancellationToken);
-        //await PutBackendInformationFiles(backendInformationFiles, cancellationToken);
-        //await PutDiagnosticInformationFiles(diagnosticInformationFiles, cancellationToken);
-        //await PutGatewayInformationFiles(gatewayInformationFiles, cancellationToken);
-        //await PutProductInformationFiles(productInformationFiles, cancellationToken);
-        //await PutProductPolicyFiles(productPolicyFiles, cancellationToken);
-        //await PutApiVersionSetInformationFiles(apiVersionSetInformationFiles, cancellationToken);
-        //await PutApiInformationAndSpecificationFiles(apiInformationFiles, apiSpecificationFiles, cancellationToken);
+        await PutNamedValueInformationFiles(namedValueInformationFiles, cancellationToken);
+        await PutPolicyFragments(policyFragmentInformationFiles, policyFragmentPolicyFiles, cancellationToken);
+        await PutServicePolicyFile(servicePolicyFiles, cancellationToken);
+        await PutLoggerInformationFiles(loggerInformationFiles, cancellationToken);
+        await PutBackendInformationFiles(backendInformationFiles, cancellationToken);
+        await PutDiagnosticInformationFiles(diagnosticInformationFiles, cancellationToken);
+        await PutGatewayInformationFiles(gatewayInformationFiles, cancellationToken);
+        await PutProductInformationFiles(productInformationFiles, cancellationToken);
+        await PutProductPolicyFiles(productPolicyFiles, cancellationToken);
+        await PutApiVersionSetInformationFiles(apiVersionSetInformationFiles, cancellationToken);
+        await PutApiInformationAndSpecificationFiles(apiInformationFiles, apiSpecificationFiles, cancellationToken);
         await PutApiGraphQLSchemaFiles(apiGraphQLFiles, cancellationToken);
         await PutApiPolicyFiles(apiPolicyFiles, cancellationToken);
         await PutApiDiagnosticInformationFiles(apiDiagnosticInformationFiles, cancellationToken);


### PR DESCRIPTION
Adds support for
- Extracting the new [ApiSchema](https://learn.microsoft.com/en-us/rest/api/apimanagement/current-ga/api-schema) resource as a GraphQL schema file
- Publishing that file as an ApiSchema resource for the API


> :warning: **Does not support other ApiSchema types.** Currently, it seems the ApiSchema resource functionality is still being worked on. This PR only supports GraphQL.