### PR TITLE
Use configuration yaml path variable for secret substitution

### DIFF
--- a/tools/azdo_pipelines/run-publisher-with-env.yaml
+++ b/tools/azdo_pipelines/run-publisher-with-env.yaml
@@ -62,7 +62,7 @@ steps:
       targetFiles: ${{ parameters.CONFIGURATION_YAML_PATH }}
       encoding: "auto"
       writeBOM: true
-      verbosity: "detailed"
+      verbosity: "off"
       actionOnMissing: "warn"
       keepToken: false
       tokenPrefix: "{#"

--- a/tools/azdo_pipelines/run-publisher-with-env.yaml
+++ b/tools/azdo_pipelines/run-publisher-with-env.yaml
@@ -19,9 +19,11 @@ parameters:
   - name: COMMIT_ID
     type: string
     default: publish-artifacts-in-last-commit
+  - name: PROCESS_SECRETS
+    type: boolean
+    default: false
 
-     
-
+    
 steps:
 - script: echo Provided configuration was ${{ parameters.CONFIGURATION_YAML_PATH }}
   displayName: Print the name of the yaml configuration file if provided
@@ -56,17 +58,18 @@ steps:
     failOnStandardError: true
 
 # replacetokens@3 task will need to be installed to use
-- task: replacetokens@3
-  displayName: 'Perform namevalue secret substitution in configuration.${{ parameters.ENVIRONMENT}}.yaml'
-  inputs:
-    targetFiles: $(Build.SourcesDirectory)/configuration.${{ parameters.ENVIRONMENT}}.yaml
-    encoding: "auto"
-    writeBOM: true
-    verbosity: "off"
-    actionOnMissing: "warn"
-    keepToken: false
-    tokenPrefix: "{#"
-    tokenSuffix: "#}"
+- ${{ if eq(parameters.PROCESS_SECRETS, true) }}:
+  - task: replacetokens@3
+    displayName: 'Perform namevalue secret substitution in ${{ parameters.CONFIGURATION_YAML_PATH }}'
+    inputs:
+      targetFiles: ${{ parameters.CONFIGURATION_YAML_PATH }}
+      encoding: "auto"
+      writeBOM: true
+      verbosity: "off"
+      actionOnMissing: "warn"
+      keepToken: false
+      tokenPrefix: "{#"
+      tokenSuffix: "#}"
 
 - task: Bash@3
   displayName: Fetch publisher

--- a/tools/azdo_pipelines/run-publisher-with-env.yaml
+++ b/tools/azdo_pipelines/run-publisher-with-env.yaml
@@ -20,7 +20,6 @@ parameters:
     type: string
     default: publish-artifacts-in-last-commit
 
-    
 steps:
 - script: echo Provided configuration was ${{ parameters.CONFIGURATION_YAML_PATH }}
   displayName: Print the name of the yaml configuration file if provided

--- a/tools/azdo_pipelines/run-publisher-with-env.yaml
+++ b/tools/azdo_pipelines/run-publisher-with-env.yaml
@@ -19,9 +19,6 @@ parameters:
   - name: COMMIT_ID
     type: string
     default: publish-artifacts-in-last-commit
-  - name: PROCESS_SECRETS
-    type: boolean
-    default: false
 
     
 steps:
@@ -58,14 +55,14 @@ steps:
     failOnStandardError: true
 
 # replacetokens@3 task will need to be installed to use
-- ${{ if eq(parameters.PROCESS_SECRETS, true) }}:
+- ${{ if ne(parameters.CONFIGURATION_YAML_PATH, '') }}:
   - task: replacetokens@3
     displayName: 'Perform namevalue secret substitution in ${{ parameters.CONFIGURATION_YAML_PATH }}'
     inputs:
       targetFiles: ${{ parameters.CONFIGURATION_YAML_PATH }}
       encoding: "auto"
       writeBOM: true
-      verbosity: "off"
+      verbosity: "detailed"
       actionOnMissing: "warn"
       keepToken: false
       tokenPrefix: "{#"

--- a/tools/azdo_pipelines/run-publisher.yaml
+++ b/tools/azdo_pipelines/run-publisher.yaml
@@ -62,6 +62,7 @@ stages:
                      API_MANAGEMENT_SERVICE_OUTPUT_FOLDER_PATH: ${{ parameters.API_MANAGEMENT_SERVICE_OUTPUT_FOLDER_PATH }}
                      RESOURCE_GROUP_NAME : $(RESOURCE_GROUP_NAME_Prod)
                      CONFIGURATION_YAML_PATH:  $(Build.SourcesDirectory)/configuration.prod.yaml
+                     PROCESS_SECRETS: true
                      ENVIRONMENT: "Prod"
                      COMMIT_ID: ${{ parameters.COMMIT_ID }}
               

--- a/tools/azdo_pipelines/run-publisher.yaml
+++ b/tools/azdo_pipelines/run-publisher.yaml
@@ -62,7 +62,6 @@ stages:
                      API_MANAGEMENT_SERVICE_OUTPUT_FOLDER_PATH: ${{ parameters.API_MANAGEMENT_SERVICE_OUTPUT_FOLDER_PATH }}
                      RESOURCE_GROUP_NAME : $(RESOURCE_GROUP_NAME_Prod)
                      CONFIGURATION_YAML_PATH:  $(Build.SourcesDirectory)/configuration.prod.yaml
-                     PROCESS_SECRETS: true
                      ENVIRONMENT: "Prod"
                      COMMIT_ID: ${{ parameters.COMMIT_ID }}
               


### PR DESCRIPTION
I'd like to suggest this fix to the handling of the token replacements for the AzDO pipelines.