### PR TITLE
Fix ambiguity with replacetokens task

### DIFF
--- a/tools/azdo_pipelines/run-publisher-with-env.yaml
+++ b/tools/azdo_pipelines/run-publisher-with-env.yaml
@@ -60,7 +60,7 @@ steps:
 
   # replacetokens@3 task will need to be installed to use
   - ${{ if ne(parameters.CONFIGURATION_YAML_PATH, '') }}:
-      - task: replacetokens@3
+      - task: qetza.replacetokens.replacetokens-task.replacetokens@3
         displayName: "Perform namevalue secret substitution in ${{ parameters.CONFIGURATION_YAML_PATH }}"
         inputs:
           targetFiles: ${{ parameters.CONFIGURATION_YAML_PATH }}


### PR DESCRIPTION
In our specific ADO organization we have two replacetokens tasks - this means we get the following error when running your template:
```
Step task reference is invalid. The task name replacetokens is ambiguous. Specify one of the following identifiers to resolve the ambiguity: qetza.replacetokens.replacetokens-task.replacetokens, colinsalmcorner.colinsalmcorner-buildtasks.replace-tokens-task.ReplaceTokens
```