### PR TITLE
Avoid getting into a infinite loop when calling Process

### DIFF
--- a/tools/code/extractor/Program.cs
+++ b/tools/code/extractor/Program.cs
@@ -258,7 +258,7 @@ public static class Program
         public override void Process(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
             RemoveAuthorizationHeader(message);
-            Process(message, pipeline);
+            ProcessNext(message, pipeline);
         }
 
         public override async ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)


### PR DESCRIPTION
When troubleshooting an authentication issue I changed the code in http.cs to call pipeline.SendRequest instead of pipeline.SendRequestAsync to make debugging easier.  This caused the Process method in the class UnauthenticatedPipelinePolicy to be called, which then it ended up in an infinite loop since the method called itself. 

I therefore changed the Process method to call ProcessNext, which worked. 

So it looks like the Process is not called but I did have great use for it when troubleshooting my issue.