### PR TITLE
Removed contact information from ApiCreateOrUpdateProperties.

### DIFF
--- a/tools/code/common/Api.cs
+++ b/tools/code/common/Api.cs
@@ -130,7 +130,6 @@ public sealed record ApiModel
                 .AddPropertyIfNotNull("apiVersionSet", ApiVersionSet?.Serialize())
                 .AddPropertyIfNotNull("apiVersionSetId", ApiVersionSetId)
                 .AddPropertyIfNotNull("authenticationSettings", AuthenticationSettings?.Serialize())
-                .AddPropertyIfNotNull("contact", Contact?.Serialize())
                 .AddPropertyIfNotNull("description", Description)
                 .AddPropertyIfNotNull("displayName", DisplayName)
                 .AddPropertyIfNotNull("format", Format?.Serialize())


### PR DESCRIPTION
This causes the API name to be set to the contact name when publishing the api. The contact information is still contained in the openapi spec files and is set correctly on apim when publishing.

fixes #213

It looks to me the microsoft.apimanagement/service gets very confused with a json tag named "name" and uses that as the API display name despite there being a displayname value and the "name" tag being inside a contact node. The real fix might actually be in that base management API instead of in this extractor/importer logic.

Also this might not be the best way to go about it. The serialize call on the apimodel is only used for writing the api information as far as I see, but if this gets reused elsewhere contact info might be wanted over there.

But right now omitting the contact info from the apiInformation.json file fixes the issue where contact name gets used as display name for the API.