### PR TITLE
Remove apiInformation.json contactinfo.

### DIFF
--- a/tools/code/extractor/Api.cs
+++ b/tools/code/extractor/Api.cs
@@ -71,6 +71,7 @@ internal static class Api
     {
         var apiInformationFile = new ApiInformationFile(apiDirectory);
         var contentJson = apiModel.Serialize();
+        contentJson["properties"]?.AsObject().Remove("contact");
 
         logger.LogInformation("Writing API information file {filePath}...", apiInformationFile.Path);
         await apiInformationFile.OverwriteWithJson(contentJson, cancellationToken);


### PR DESCRIPTION
Lightweight change that only affects the apiInformation file and leaves the common code intact.

fixes  #213

Is a less impactful fix than just removing contact info in the common library.

This could be a temporary workaround to tide over the period until the API management team fixes the issue on their side.