### PR TITLE
Add environment variable for github action workflow to allow changes to .Net LogLevel

### DIFF
--- a/tools/github_workflows/run-publisher-with-env.yaml
+++ b/tools/github_workflows/run-publisher-with-env.yaml
@@ -18,7 +18,7 @@ on:
 
 env:
   apiops_release_version: desired-version-goes-here
-  #By default, this will be Information but if you want something different you will need to add a variable in the Settings -> Environment -> Variables section
+  #By default, this will be Information but if you want something different you will need to add a variable in the Settings -> Environment -> Environment variables section
   Logging__LogLevel__Default: ${{ vars.LOG_LEVEL }}
 
 jobs:

--- a/tools/github_workflows/run-publisher-with-env.yaml
+++ b/tools/github_workflows/run-publisher-with-env.yaml
@@ -18,6 +18,8 @@ on:
 
 env:
   apiops_release_version: desired-version-goes-here
+  #By default, this will be Information but if you want something different you will need to add a variable in the Settings -> Environment -> Variables section
+  Logging__LogLevel__Default: ${{ vars.LOG_LEVEL }}
 
 jobs:
   build:


### PR DESCRIPTION
Adding a change to the `run-publisher-with-env.yaml` pipeline to allow you to change the .Net logging level from `Information` to whatever you wish.  If the consumer doesn't wish to change it nothing is required, but if they do they simply need to add an environment variable named `LOG_LEVEL` to their repo or enterprise.

I also recommend changing the [Logging Wiki](https://github.com/Azure/apiops/wiki/Logging#debug) to read something like this for the github section:

>You can also do this in Github by setting a variable named `LOG_LEVEL` for the appropriate environment as demonstrated [here](https://docs.github.com/en/actions/learn-github-actions/variables).