### PR TITLE
Lookup and apply serviceUrl when specification.yaml by itself

### DIFF
--- a/tools/code/common/Http.cs
+++ b/tools/code/common/Http.cs
@@ -24,9 +24,11 @@ public static class HttpPipelineExtensions
         {
             var responseJson = await pipeline.GetJsonObject(nextLink, cancellationToken);
 
+            // This is a workaround for the fact that the Azure REST APIs return inconsistent JSON for list operations.
+            // Sometimes the JSON returned is a simple array of JSON objects, and sometimes it is an object with a "value" property that is an array of JSON objects.
             var values = responseJson.TryGetJsonArrayProperty("value")
                                      .Map(jsonArray => jsonArray.Choose(node => node as JsonObject))
-                         ?? Enumerable.Empty<JsonObject>();
+                         ?? responseJson.Choose(node => node.Value as JsonObject);
 
             foreach (var value in values)
             {

--- a/tools/code/publisher/Service.cs
+++ b/tools/code/publisher/Service.cs
@@ -18,7 +18,7 @@ internal static class Service
         await ApiTag.ProcessDeletedArtifacts(files, configurationJson, serviceDirectory, serviceUri, listRestResources, putRestResource, deleteRestResource, logger, cancellationToken);
         await ApiDiagnostic.ProcessDeletedArtifacts(files, serviceDirectory, serviceUri, deleteRestResource, logger, cancellationToken);
         await ApiPolicy.ProcessDeletedArtifacts(files, serviceDirectory, serviceUri, deleteRestResource, logger, cancellationToken);
-        await Api.ProcessDeletedArtifacts(files, configurationJson, serviceDirectory, serviceUri, putRestResource, deleteRestResource, logger, cancellationToken);
+        await Api.ProcessDeletedArtifacts(files, configurationJson, serviceDirectory, serviceUri, listRestResources, putRestResource, deleteRestResource, logger, cancellationToken);
         await Subscription.ProcessDeletedArtifacts(files, serviceDirectory, serviceUri, deleteRestResource, logger, cancellationToken);
         await ProductTag.ProcessDeletedArtifacts(files, configurationJson, serviceDirectory, serviceUri, listRestResources, putRestResource, deleteRestResource, logger, cancellationToken);
         await ProductGroup.ProcessDeletedArtifacts(files, configurationJson, serviceDirectory, serviceUri, listRestResources, putRestResource, deleteRestResource, logger, cancellationToken);
@@ -50,7 +50,7 @@ internal static class Service
         await ProductPolicy.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, putRestResource, logger, cancellationToken);
         await ProductGroup.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, listRestResources, putRestResource, deleteRestResource, logger, cancellationToken);
         await ProductTag.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, listRestResources, putRestResource, deleteRestResource, logger, cancellationToken);
-        await Api.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, putRestResource, logger, cancellationToken);
+        await Api.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, listRestResources, putRestResource, logger, cancellationToken);
         await ApiPolicy.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, putRestResource, logger, cancellationToken);
         await ApiDiagnostic.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, putRestResource, logger, cancellationToken);
         await ApiTag.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, listRestResources, putRestResource, deleteRestResource, logger, cancellationToken);


### PR DESCRIPTION
I'd like to submit this PR as a temporary fix to issue #275.  The change is minor for the most part, but did need to add the ability to call out to the API Management api to get the current serviceUrl so it could be merged back as part of the PUT request for the update.  It only does this when the specification.yaml is part of the commit without an accompanying apiInformation.json.

I did need to change the HTTP class due to how it was assuming all valid responses would be in the `value` json property, so please confirm there are no issues with that.