### PR TITLE
[Fix] Publisher V4.1.x on deleting Products

### DIFF
--- a/tools/code/publisher/Product.cs
+++ b/tools/code/publisher/Product.cs
@@ -1,12 +1,14 @@
 ﻿using common;
 using Microsoft.Extensions.Logging;
 using MoreLinq;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web;
 
 namespace publisher;
 
@@ -75,7 +77,11 @@ internal static class Product
         var uri = GetProductUri(productName, serviceUri);
 
         logger.LogInformation("Deleting product {productName}...", productName);
-        await deleteRestResource(uri.Uri, cancellationToken);
+        var builder = new UriBuilder(uri.Uri);
+        var query = HttpUtility.ParseQueryString(builder.Query);
+        query["deleteSubscriptions"] = "true";
+        builder.Query = query.ToString();
+        await deleteRestResource(builder.Uri, cancellationToken);
     }
 
     public static ProductUri GetProductUri(ProductName productName, ServiceUri serviceUri)

--- a/tools/code/publisher/ProductApi.cs
+++ b/tools/code/publisher/ProductApi.cs
@@ -30,6 +30,7 @@ internal static class ProductApi
         var configurationArtifacts = GetConfigurationProductApis(configurationJson);
 
         return GetProductApisFiles(files, serviceDirectory)
+                .Where(file => File.Exists(file.Path.ToString()))
                 .Select(file =>
                 {
                     var productName = GetProductName(file);

--- a/tools/code/publisher/ProductGroup.cs
+++ b/tools/code/publisher/ProductGroup.cs
@@ -30,6 +30,7 @@ internal static class ProductGroup
         var configurationArtifacts = GetConfigurationProductGroups(configurationJson);
 
         return GetProductGroupsFiles(files, serviceDirectory)
+                .Where(file => File.Exists(file.Path.ToString()))
                 .Select(file =>
                 {
                     var productName = GetProductName(file);


### PR DESCRIPTION
[BUG] Publisher V4.1.0 on deleting Product Directory - Publisher is still trying to read deleted files for productapi's and productgroups 

fix on bug #242

Added querystring parameter delete subscriptions on Delete of Product
@guythetechie  please review