### PR TITLE
Detect if the azure cli is logged into account with multiple subscriptions

### DIFF
--- a/tools/azdo_pipelines/run-extractor.yaml
+++ b/tools/azdo_pipelines/run-extractor.yaml
@@ -62,7 +62,24 @@ stages:
                 Write-Host "##vso[task.setvariable issecret=true;variable=AZURE_CLIENT_ID]$env:servicePrincipalId"
                 Write-Host "##vso[task.setvariable issecret=true;variable=AZURE_CLIENT_SECRET]$env:servicePrincipalKey"
                 Write-Host "##vso[task.setvariable issecret=true;variable=AZURE_TENANT_ID]$env:tenantId"
-                Write-Host "##vso[task.setvariable issecret=true;variable=AZURE_SUBSCRIPTION_ID]$(az account show --query "id" --output tsv)"
+                
+                if (-not $env:AZURE_SUBSCRIPTION_ID) {
+                    $subscriptionCount = az account list --query "length([])" --output tsv
+                    if ($subscriptionCount -eq 1) {
+                        $subscriptionId = az account list --query "[0].id" --output tsv
+                        Write-Host "Setting AZURE_SUBSCRIPTION_ID environment variable to: $subscriptionId"
+                        #$env:AZURE_SUBSCRIPTION_ID = $subscriptionId
+                        Write-Host "##vso[task.setvariable issecret=true;variable=AZURE_SUBSCRIPTION_ID]$($subscriptionId)"
+                    } 
+                    elseif ($subscriptionCount -gt 1) {
+                        Write-Host "Multiple subscriptions are accessible. Please set the AZURE_SUBSCRIPTION_ID environment variable manually."
+                        exit 1
+                    }
+                }
+                else {
+                  Write-Host "AZURE_SUBSCRIPTION_ID is already set to: $env:AZURE_SUBSCRIPTION_ID"
+                }
+
               addSpnToEnvironment: true
               failOnStandardError: true
           - task: PowerShell@2


### PR DESCRIPTION
Carried modifications to the extractor pipeline to identify whether the logged Azure account is associated with multiple subscriptions. This change addresses the unintended consequence of the current implementation, which selects the first subscription by default.