### PR TITLE
Throw informative error if the specification file is invalid.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,7 @@ MigrationBackup/
 appsettings.json
 /tools/code/extractor/Properties/launchSettings.json
 /tools/code/publisher/Properties/launchSettings.json
+
+# These files are your personal settings - don't commit them to source control.
+tools/code/.env.publisher
+tools/code/.env.extractor

--- a/tools/README.md
+++ b/tools/README.md
@@ -15,8 +15,8 @@ This option allows you to run the extractor and publisher binaries on your local
   az ad sp create-for-rbac --name myApp --role contributor --scopes /subscriptions/{subscription-id}/resourceGroups/exampleRG --sdk-auth
   ```
 * The output is a JSON object with the role assignment credentials. Copy this JSON object for later. You'll only need the sections with the clientId, clientSecret, subscriptionId, and tenantId values.
-* Update the values in the `.env.extractor` file to include the information required for the extractor to run sucessfully.
-* Update the values in the `.env.publisher` file to include the information required for the publisher to run sucessfully
+* Copy and rename `./tools/code/.env.extractor.template` to `./tools/code/.env.extractor` and update the values to include the information required for the extractor to run sucessfully. This file will not be committed to source control
+* Copy and rename `./tools/code/.env.publisher.template` to `./tools/code/.env.publisher` and update the values to include the information required for the publisher to run sucessfully. This file will not be committed to source control
 * Place a breakpoint on the opened source code file
 * Run the "Launch Extractor" from the debugger section in VS Code to debug the extractor
 * Run the "Launch Publisher" from the debugger section in VS Code to debug the publisher
@@ -40,8 +40,8 @@ This option allows you to run the extractor and publisher binaries in a containe
   az ad sp create-for-rbac --name myApp --role contributor --scopes /subscriptions/{subscription-id}/resourceGroups/exampleRG --sdk-auth
   ```
 * The output is a JSON object with the role assignment credentials. Copy this JSON object for later. You'll only need the sections with the clientId, clientSecret, subscriptionId, and tenantId values.
-* Update the values in the `.env.extractor` file to include the information required for the extractor to run sucessfully.
-* Update the values in the `.env.publisher` file to include the information required for the publisher to run sucessfully
+* Copy and rename `./tools/code/.env.extractor.template` to `./tools/code/.env.extractor` and update the values to include the information required for the extractor to run sucessfully. This file will not be committed to source control
+* Copy and rename `./tools/code/.env.publisher.template` to `./tools/code/.env.publisher` and update the values to include the information required for the publisher to run sucessfully. This file will not be committed to source control
 * Place a breakpoint on the opened source code file
 * Run the "Launch Extractor" from the debugger section in VS Code (remember that Github Codespaces runs VS Code in the browser) to debug the extractor
 * Run the "Launch Publisher" from the debugger section in VS Code (remember that Github Codespaces runs VS Code in the browser) to debug the publisher

--- a/tools/code/.env.extractor.template
+++ b/tools/code/.env.extractor.template
@@ -1,4 +1,5 @@
-#Extractor environment variables
+# Extractor environment variables
+## Please make a copy of this and rename it to `.env.extractor`
 AZURE_RESOURCE_GROUP_NAME=<source apim instance resource group>
 API_MANAGEMENT_SERVICE_NAME=<source apim instance name>
 AZURE_CLIENT_ID=<AZURE_CLIENT_ID>

--- a/tools/code/.env.publisher.template
+++ b/tools/code/.env.publisher.template
@@ -1,4 +1,5 @@
-#Publisher environment variables
+# Publisher environment variables
+## Please make a copy of this and rename it to `.env.publisher`
 AZURE_RESOURCE_GROUP_NAME=<destination apim instance resource group>
 AZURE_CLIENT_ID=<AZURE_CLIENT_ID>
 AZURE_CLIENT_SECRET=<AZURE_CLIENT_SECRET>

--- a/tools/code/publisher/Api.cs
+++ b/tools/code/publisher/Api.cs
@@ -352,6 +352,10 @@ internal static class Api
     {
         using var fileStream = openApiSpecificationFile.ReadAsStream();
         var readResult = await new OpenApiStreamReader().ReadAsync(fileStream);
+        if (readResult.OpenApiDiagnostic.Errors.Any())
+        {
+            throw new IOException($"Could not read OpenAPI specification file {openApiSpecificationFile.Path}.");
+        }
         return readResult.OpenApiDocument.Serialize(openApiSpecificationFile.Version, openApiSpecificationFile.Format);
     }
 


### PR DESCRIPTION
Due to an unforeseen bug we had an invalid Specification file. It was hard to track down what the error was in a large codebase. This small change throws the error of the invalid file (rather than an InvalidArgumentException which is the current behaviour).

I've also renamed the .env.extractor/.env.publisher files to be suffixed with .template as it's pretty common practice to not have these files in source control, but still provide your users the list of the required values. In it's current form, I will always be shown that there is a git change. It's easy that these files are .gitignore