### PR TITLE
alphabetically order apiFiles before PUT

### DIFF
--- a/tools/code/publisher/Api.cs
+++ b/tools/code/publisher/Api.cs
@@ -53,12 +53,14 @@ internal static class Api
         var specificationFiles = files.Choose(file => TryGetApiSpecificationFile(file, serviceDirectory))
                                       .Select(specificationFile => (ApiName: GetApiName(specificationFile), SpecificationFile: specificationFile));
 
-        return informationFiles.FullJoin(specificationFiles,
+        var apiFiles = informationFiles.FullJoin(specificationFiles,
                                          firstKeySelector: informationFile => informationFile.ApiName,
                                          secondKeySelector: specificationFile => specificationFile.ApiName,
                                          firstSelector: informationFile => (informationFile.ApiName, (ApiInformationFile?)informationFile.File, (ApiSpecificationFile?)null),
                                          secondSelector: schema => (schema.ApiName, null, schema.SpecificationFile),
                                          bothSelector: (informationFile, specificationFile) => (informationFile.ApiName, informationFile.File, specificationFile.SpecificationFile));
+
+        return apiFiles.OrderBy(a => a.ApiName.ToString());
     }
 
     private static ApiInformationFile? TryGetInformationFile(FileInfo? file, ServiceDirectory serviceDirectory)


### PR DESCRIPTION
Corresponds to bug #371. All revisions should be deployed. 

Currently, the APIs are deployed in random order, so revision 2 can be deployed before revision 1, which causes rev 1 to be missed. 

Alphabetically ordering the API files prior to the PUT requests ensures that the list of files fed to [.ForEachParallel](https://github.com/Azure/apiops/blob/main/tools/code/publisher/Api.cs#L387) is set in the correct order - v3 will come after v2 and v1/original, and rev3 will come after rev2 and rev1, so on and so forth.

I deployed the SampleArtifacts with an additional Swagger Petstore API to demonstrate the initial issue:
<img width="1078" alt="petstorebefore" src="https://github.com/Azure/apiops/assets/16926044/b4569b5b-390a-4e1c-9405-159c83ae340e">

<img width="1079" alt="testapibefore" src="https://github.com/Azure/apiops/assets/16926044/70227e75-d9ff-4065-88f0-6d8d30f15061">

<img width="1081" alt="versionedapibefore" src="https://github.com/Azure/apiops/assets/16926044/4ce016ce-6195-48fa-be00-bc4e9b5bcf3f">

The same APIs have all revisions deployed after the change, with correct isCurrent and isOnline properties:
<img width="1085" alt="petstoreafter" src="https://github.com/Azure/apiops/assets/16926044/124db516-8e11-42e3-996e-d48f73e2bfb6">

<img width="1086" alt="testapiafter" src="https://github.com/Azure/apiops/assets/16926044/c3cde889-bd18-4e69-9ea6-27cfd2d211cf">

<img width="1083" alt="versionedapiafter" src="https://github.com/Azure/apiops/assets/16926044/1cb90051-5ded-4ef7-a57d-c8e1b97f3e2a">


@waelkdouh and @guythetechie 
The `.ForEachParallel` on line 387 of `Api.cs` in the publisher means that the APIs can still be deployed in incorrect order. While the list itself that is fed to `.ForEachParallel` is in now in the correct order, the parallel nature of the executions may result in order issues. In the deployment logs below, you can see that the PUT request for `myversionedapi-v2` occurred before the PUT for `myversionedapi`.

Updating the `.ForEachParallel` to a `.ForEach` ensures the PUT requests are made in the correct order. I have deployed using `.ForEachParallel` many times and have not been able to actually cause an error or any deployment issues, though the version order can be incorrect, so I haven't made any updates here.

The logs before the change were as follows:
```
info: Publisher[0]
      Putting apiVersionSet 6286439d9a310d01468c083c...
Publisher: Information: Putting apiVersionSet 6286439d9a310d01468c083c...
info: Publisher[0]
      Putting API myversionedapi...
Publisher: Information: Putting API myversionedapi...
Publisher: Information: Putting API testapi;rev=2...
info: Publisher[0]
      Putting API testapi;rev=2...
info: Publisher[0]
      Putting API myversionedapi-v2;rev=2...
Publisher: Information: Putting API myversionedapi-v2;rev=2...
info: Publisher[0]
      Putting API myversionedapi-v2...
Publisher: Information: Putting API myversionedapi-v2...
info: Publisher[0]
      Putting API unversioned-petstore;rev=2...
Publisher: Information: Putting API unversioned-petstore;rev=2...
Publisher: Information: Putting API testapi...
info: Publisher[0]
      Putting API testapi...
info: Publisher[0]
      Putting API unversioned-petstore...
Publisher: Information: Putting API unversioned-petstore...
info: Publisher[0]
      Execution complete.
Publisher: Information: Execution complete.
info: Microsoft.Hosting.Lifetime[0]
      Application is shutting down...
Microsoft.Hosting.Lifetime: Information: Application is shutting down...
```
The logs after the change were as follows:
```
info: Publisher[0]
      Putting apiVersionSet 6286439d9a310d01468c083c...
Publisher: Information: Putting apiVersionSet 6286439d9a310d01468c083c...
Publisher: Information: Putting API myversionedapi-v2...
info: Publisher[0]
      Putting API myversionedapi-v2...
info: Publisher[0]
      Putting API myversionedapi...
Publisher: Information: Putting API myversionedapi...
info: Publisher[0]
      Putting API myversionedapi-v2;rev=2...
Publisher: Information: Putting API myversionedapi-v2;rev=2...
info: Publisher[0]
      Putting API testapi...
Publisher: Information: Putting API testapi...
info: Publisher[0]
      Putting API testapi;rev=2...
Publisher: Information: Putting API testapi;rev=2...
info: Publisher[0]
      Putting API unversioned-petstore...
Publisher: Information: Putting API unversioned-petstore...
Publisher: Information: Putting API unversioned-petstore;rev=2...
info: Publisher[0]
      Putting API unversioned-petstore;rev=2...
info: Publisher[0]
      Execution complete.
Publisher: Information: Execution complete.
info: Microsoft.Hosting.Lifetime[0]
      Application is shutting down...
```

If I change .ForEachParallel to .ForEach:
```
info: Publisher[0]
      Putting apiVersionSet 6286439d9a310d01468c083c...
Publisher: Information: Putting apiVersionSet 6286439d9a310d01468c083c...
info: Publisher[0]
      Putting API myversionedapi...
Publisher: Information: Putting API myversionedapi...
info: Publisher[0]
      Putting API myversionedapi-v2...
Publisher: Information: Putting API myversionedapi-v2...
info: Publisher[0]
      Putting API myversionedapi-v2;rev=2...
Publisher: Information: Putting API myversionedapi-v2;rev=2...
info: Publisher[0]
      Putting API testapi...
Publisher: Information: Putting API testapi...
Publisher: Information: Putting API testapi;rev=2...
info: Publisher[0]
      Putting API testapi;rev=2...
info: Publisher[0]
      Putting API unversioned-petstore...
Publisher: Information: Putting API unversioned-petstore...
info: Publisher[0]
      Putting API unversioned-petstore;rev=2...
Publisher: Information: Putting API unversioned-petstore;rev=2...
info: Publisher[0]
      Execution complete.
Publisher: Information: Execution complete.
info: Microsoft.Hosting.Lifetime[0]
      Application is shutting down...
Microsoft.Hosting.Lifetime: Information: Application is shutting down...
```