### PR TITLE
Spectral should run after source code checkout

### DIFF
--- a/tools/github_workflows/run-publisher-with-env.yaml
+++ b/tools/github_workflows/run-publisher-with-env.yaml
@@ -26,17 +26,17 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.API_MANAGEMENT_ENVIRONMENT }}
     steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+    
       # Run Spectral
       - uses: actions/setup-node@v3
         with:
           node-version: "14"
       - run: npm install -g @stoplight/spectral
       - run: spectral lint "${{ GITHUB.WORKSPACE }}/${{ inputs.API_MANAGEMENT_SERVICE_OUTPUT_FOLDER_PATH }}\apis\*.{json,yml,yaml}" --ruleset https://raw.githubusercontent.com/connectedcircuits/devops-api-linter/main/rules.yaml
-
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
 
       # Add this step for each APIM environment and pass specific set of secrets that you want replaced in the env section below
       - name: "Perform namevalue secret substitution in configuration.${{ inputs.API_MANAGEMENT_ENVIRONMENT}}.yaml"


### PR DESCRIPTION
Current implementation runs spectral without having the source code available. This PR fixes that.