### PR TITLE
This small change will resolve one part of this bug #413 (will resolve for closed products(needs subscription).

### DIFF
--- a/tools/code/extractor/ProductApi.cs
+++ b/tools/code/extractor/ProductApi.cs
@@ -21,11 +21,8 @@ internal static class ProductApi
                                     .Select(SerializeProductApi)
                                     .ToJsonArray(cancellationToken);
 
-        if (productApis.Any())
-        {
-            logger.LogInformation("Writing product APIs file {filePath}...", productApisFile.Path);
-            await productApisFile.OverwriteWithJson(productApis, cancellationToken);
-        }
+       logger.LogInformation("Writing product APIs file {filePath}...", productApisFile.Path);
+       await productApisFile.OverwriteWithJson(productApis, cancellationToken);        
     }
 
     private static IAsyncEnumerable<ApiName> List(ProductUri productUri, ListRestResources listRestResources, CancellationToken cancellationToken)


### PR DESCRIPTION
This small change will resolve one part of this bug https://github.com/Azure/apiops/issues/413 (will resolve for closed products(needs subscription).

basically with this change we are going to have an empty json and with that the login inside the productApi on the publisher will work correctly.

For open products, i am looking in how we can change the behavior. but if you run again the publisher it will work also for open products.

@guythetechie could you take a look