### PR TITLE
Fix for hard-coded api-version

### DIFF
--- a/tools/code/common/PolicyFragment.cs
+++ b/tools/code/common/PolicyFragment.cs
@@ -10,9 +10,7 @@ public sealed record PolicyFragmentsUri : IArtifactUri
 
     public PolicyFragmentsUri(ServiceUri serviceUri)
     {
-        Uri = serviceUri.AppendPath("policyFragments")
-                        .SetQueryParam("api-version", "2022-04-01-preview")
-                        .ToUri();
+        Uri = serviceUri.AppendPath("policyFragments");
     }
 }
 

--- a/tools/code/extractor/Api.cs
+++ b/tools/code/extractor/Api.cs
@@ -130,7 +130,6 @@ internal static class Api
     {
         var exportUri = apiUri.Uri.SetQueryParam("format", format)
                                   .SetQueryParam("export", "true")
-                                  .SetQueryParam("api-version", "2021-08-01")
                                   .ToUri();
 
         var exportResponse = await getRestResource(exportUri, cancellationToken);


### PR DESCRIPTION
PR to fix issue #467

Removing query param override in `common/PolicyFragments.cs` and `extractor/Api.cs` to make sure tha api version comes from ARM_API_VERSION parameter only.  