### PR TITLE
added POLICY_SPECIFICATION_FORMAT with possible values rawxml or xml.…

### DIFF
--- a/tools/code/common/ApiOperationPolicy.cs
+++ b/tools/code/common/ApiOperationPolicy.cs
@@ -34,10 +34,10 @@ public sealed record ApiOperationPolicyUri : IArtifactUri
 {
     public Uri Uri { get; }
 
-    public ApiOperationPolicyUri(ApiOperationPolicyName policyName, ApiOperationPoliciesUri apiOperationPoliciesUri)
+    public ApiOperationPolicyUri(ApiOperationPolicyName policyName, ApiOperationPoliciesUri apiOperationPoliciesUri, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification)
     {
         Uri = apiOperationPoliciesUri.AppendPath(policyName.ToString())
-                                     .SetQueryParam("format", "rawxml")
+                                     .SetQueryParam("format", defaultPolicyXmlSpecification.Format)
                                      .ToUri();
     }
 }

--- a/tools/code/common/ApiPolicy.cs
+++ b/tools/code/common/ApiPolicy.cs
@@ -34,10 +34,10 @@ public sealed record ApiPolicyUri : IArtifactUri
 {
     public Uri Uri { get; }
 
-    public ApiPolicyUri(ApiPolicyName policyName, ApiPoliciesUri apiPoliciesUri)
+    public ApiPolicyUri(ApiPolicyName policyName, ApiPoliciesUri apiPoliciesUri, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification)
     {
         Uri = apiPoliciesUri.AppendPath(policyName.ToString())
-                            .SetQueryParam("format", "rawxml")
+                            .SetQueryParam("format", defaultPolicyXmlSpecification.Format)
                             .ToUri();
     }
 }

--- a/tools/code/common/DefaultPolicyXmlSpecification.cs
+++ b/tools/code/common/DefaultPolicyXmlSpecification.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace common
+{
+    public abstract record DefaultPolicyXmlSpecification
+    {
+        public abstract string Format { get; }
+        public record RawXmlFormat : DefaultPolicyXmlSpecification
+        {
+            public override string Format => "rawxml";
+        }
+        public record XmlFormat : DefaultPolicyXmlSpecification
+        {
+            public override string Format => "xml";
+        }
+    }
+}

--- a/tools/code/common/PolicyFragment.cs
+++ b/tools/code/common/PolicyFragment.cs
@@ -50,10 +50,10 @@ public sealed record PolicyFragmentUri : IArtifactUri
 {
     public Uri Uri { get; }
 
-    public PolicyFragmentUri(PolicyFragmentName policyFragmentName, PolicyFragmentsUri policyFragmentsUri)
+    public PolicyFragmentUri(PolicyFragmentName policyFragmentName, PolicyFragmentsUri policyFragmentsUri, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification)
     {
         Uri = policyFragmentsUri.AppendPath(policyFragmentName.ToString())
-                                .SetQueryParam("format", "rawxml")
+                                .SetQueryParam("format", defaultPolicyXmlSpecification.Format)
                                 .ToUri();
     }
 }

--- a/tools/code/common/ProductPolicy.cs
+++ b/tools/code/common/ProductPolicy.cs
@@ -34,10 +34,10 @@ public sealed record ProductPolicyUri : IArtifactUri
 {
     public Uri Uri { get; }
 
-    public ProductPolicyUri(ProductPolicyName policyName, ProductPoliciesUri productPoliciesUri)
+    public ProductPolicyUri(ProductPolicyName policyName, ProductPoliciesUri productPoliciesUri, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification)
     {
         Uri = productPoliciesUri.AppendPath(policyName.ToString())
-                                .SetQueryParam("format", "rawxml")
+                                .SetQueryParam("format", defaultPolicyXmlSpecification.Format)
                                 .ToUri();
     }
 }

--- a/tools/code/common/ServicePolicy.cs
+++ b/tools/code/common/ServicePolicy.cs
@@ -34,10 +34,10 @@ public sealed record ServicePolicyUri : IArtifactUri
 {
     public Uri Uri { get; }
 
-    public ServicePolicyUri(ServicePolicyName policyName, ServicePoliciesUri servicePoliciesUri)
+    public ServicePolicyUri(ServicePolicyName policyName, ServicePoliciesUri servicePoliciesUri, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification)
     {
         Uri = servicePoliciesUri.AppendPath(policyName.ToString())
-                                .SetQueryParam("format", "rawxml")
+                                .SetQueryParam("format", defaultPolicyXmlSpecification.Format)
                                 .ToUri();
     }
 }

--- a/tools/code/extractor/ApiOperation.cs
+++ b/tools/code/extractor/ApiOperation.cs
@@ -9,10 +9,10 @@ namespace extractor;
 
 internal static class ApiOperation
 {
-    public static async ValueTask ExportAll(ApiUri apiUri, ApiDirectory apiDirectory, ListRestResources listRestResources, GetRestResource getRestResource, ILogger logger, CancellationToken cancellationToken)
+    public static async ValueTask ExportAll(ApiUri apiUri, ApiDirectory apiDirectory, ListRestResources listRestResources, GetRestResource getRestResource, ILogger logger, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification, CancellationToken cancellationToken)
     {
         await List(apiUri, listRestResources, cancellationToken)
-                .ForEachParallel(async operationName => await Export(apiDirectory, apiUri, operationName, listRestResources, getRestResource, logger, cancellationToken),
+                .ForEachParallel(async operationName => await Export(apiDirectory, apiUri, operationName, listRestResources, getRestResource, logger, defaultPolicyXmlSpecification, cancellationToken),
                                  cancellationToken);
     }
 
@@ -24,7 +24,7 @@ internal static class ApiOperation
                                    .Select(name => new ApiOperationName(name));
     }
 
-    private static async ValueTask Export(ApiDirectory apiDirectory, ApiUri apiUri, ApiOperationName apiOperationName, ListRestResources listRestResources, GetRestResource getRestResource, ILogger logger, CancellationToken cancellationToken)
+    private static async ValueTask Export(ApiDirectory apiDirectory, ApiUri apiUri, ApiOperationName apiOperationName, ListRestResources listRestResources, GetRestResource getRestResource, ILogger logger, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification, CancellationToken cancellationToken)
     {
         var apiOperationsDirectory = new ApiOperationsDirectory(apiDirectory);
         var apiOperationDirectory = new ApiOperationDirectory(apiOperationName, apiOperationsDirectory);
@@ -32,11 +32,11 @@ internal static class ApiOperation
         var apiOperationsUri = new ApiOperationsUri(apiUri);
         var apiOperationUri = new ApiOperationUri(apiOperationName, apiOperationsUri);
 
-        await ExportPolicies(apiOperationDirectory, apiOperationUri, listRestResources, getRestResource, logger, cancellationToken);
+        await ExportPolicies(apiOperationDirectory, apiOperationUri, listRestResources, getRestResource, logger, defaultPolicyXmlSpecification, cancellationToken);
     }
 
-    private static async ValueTask ExportPolicies(ApiOperationDirectory apiOperationDirectory, ApiOperationUri apiOperationUri, ListRestResources listRestResources, GetRestResource getRestResource, ILogger logger, CancellationToken cancellationToken)
+    private static async ValueTask ExportPolicies(ApiOperationDirectory apiOperationDirectory, ApiOperationUri apiOperationUri, ListRestResources listRestResources, GetRestResource getRestResource, ILogger logger, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification, CancellationToken cancellationToken)
     {
-        await ApiOperationPolicy.ExportAll(apiOperationDirectory, apiOperationUri, listRestResources, getRestResource, logger, cancellationToken);
+        await ApiOperationPolicy.ExportAll(apiOperationDirectory, apiOperationUri, listRestResources, getRestResource, logger, defaultPolicyXmlSpecification, cancellationToken);
     }
 }

--- a/tools/code/extractor/ApiOperationPolicy.cs
+++ b/tools/code/extractor/ApiOperationPolicy.cs
@@ -9,10 +9,10 @@ namespace extractor;
 
 internal static class ApiOperationPolicy
 {
-    public static async ValueTask ExportAll(ApiOperationDirectory apiOperationDirectory, ApiOperationUri apiOperationUri, ListRestResources listRestResources, GetRestResource getRestResource, ILogger logger, CancellationToken cancellationToken)
+    public static async ValueTask ExportAll(ApiOperationDirectory apiOperationDirectory, ApiOperationUri apiOperationUri, ListRestResources listRestResources, GetRestResource getRestResource, ILogger logger, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification, CancellationToken cancellationToken)
     {
         await List(apiOperationUri, listRestResources, cancellationToken)
-                .ForEachParallel(async policyName => await Export(apiOperationDirectory, apiOperationUri, policyName, getRestResource, logger, cancellationToken),
+                .ForEachParallel(async policyName => await Export(apiOperationDirectory, apiOperationUri, policyName, getRestResource, logger, defaultPolicyXmlSpecification, cancellationToken),
                                  cancellationToken);
     }
 
@@ -24,12 +24,12 @@ internal static class ApiOperationPolicy
                                 .Select(name => new ApiOperationPolicyName(name));
     }
 
-    private static async ValueTask Export(ApiOperationDirectory apiOperationDirectory, ApiOperationUri apiOperationUri, ApiOperationPolicyName policyName, GetRestResource getRestResource, ILogger logger, CancellationToken cancellationToken)
+    private static async ValueTask Export(ApiOperationDirectory apiOperationDirectory, ApiOperationUri apiOperationUri, ApiOperationPolicyName policyName, GetRestResource getRestResource, ILogger logger, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification, CancellationToken cancellationToken)
     {
         var policyFile = new ApiOperationPolicyFile(policyName, apiOperationDirectory);
 
         var policiesUri = new ApiOperationPoliciesUri(apiOperationUri);
-        var policyUri = new ApiOperationPolicyUri(policyName, policiesUri);
+        var policyUri = new ApiOperationPolicyUri(policyName, policiesUri, defaultPolicyXmlSpecification);
         var responseJson = await getRestResource(policyUri.Uri, cancellationToken);
         var policyContent = responseJson.GetJsonObjectProperty("properties")
                                         .GetStringProperty("value");

--- a/tools/code/extractor/ApiPolicy.cs
+++ b/tools/code/extractor/ApiPolicy.cs
@@ -9,10 +9,10 @@ namespace extractor;
 
 internal static class ApiPolicy
 {
-    public static async ValueTask ExportAll(ApiDirectory apiDirectory, ApiUri apiUri, ListRestResources listRestResources, GetRestResource getRestResource, ILogger logger, CancellationToken cancellationToken)
+    public static async ValueTask ExportAll(ApiDirectory apiDirectory, ApiUri apiUri, ListRestResources listRestResources, GetRestResource getRestResource, ILogger logger, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification, CancellationToken cancellationToken)
     {
         await List(apiUri, listRestResources, cancellationToken)
-                .ForEachParallel(async policyName => await Export(apiDirectory, apiUri, policyName, getRestResource, logger, cancellationToken),
+                .ForEachParallel(async policyName => await Export(apiDirectory, apiUri, policyName, getRestResource, logger, defaultPolicyXmlSpecification, cancellationToken),
                                  cancellationToken);
     }
 
@@ -24,12 +24,12 @@ internal static class ApiPolicy
                                 .Select(name => new ApiPolicyName(name));
     }
 
-    private static async ValueTask Export(ApiDirectory apiDirectory, ApiUri apiUri, ApiPolicyName policyName, GetRestResource getRestResource, ILogger logger, CancellationToken cancellationToken)
+    private static async ValueTask Export(ApiDirectory apiDirectory, ApiUri apiUri, ApiPolicyName policyName, GetRestResource getRestResource, ILogger logger, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification, CancellationToken cancellationToken)
     {
         var policyFile = new ApiPolicyFile(policyName, apiDirectory);
 
         var policiesUri = new ApiPoliciesUri(apiUri);
-        var policyUri = new ApiPolicyUri(policyName, policiesUri);
+        var policyUri = new ApiPolicyUri(policyName, policiesUri, defaultPolicyXmlSpecification);
         var responseJson = await getRestResource(policyUri.Uri, cancellationToken);
         var policyContent = responseJson.GetJsonObjectProperty("properties")
                                         .GetStringProperty("value");

--- a/tools/code/extractor/Extractor.cs
+++ b/tools/code/extractor/Extractor.cs
@@ -15,6 +15,7 @@ internal class Extractor : BackgroundService
         public required ServiceDirectory ServiceDirectory { get; init; }
         public required ServiceUri ServiceUri { get; init; }
         public required DefaultApiSpecification DefaultApiSpecification { get; init; }
+        public required DefaultPolicyXmlSpecification DefaultPolicyXmlSpecification { get; init; }
         public required ListRestResources ListRestResources { get; init; }
         public required GetRestResource GetRestResource { get; init; }
         public required DownloadResource DownloadResource { get; init; }
@@ -71,6 +72,7 @@ internal class Extractor : BackgroundService
         await Service.Export(parameters.ServiceDirectory,
                              parameters.ServiceUri,
                              parameters.DefaultApiSpecification,
+                             parameters.DefaultPolicyXmlSpecification,
                              parameters.ApiNamesToExport,
                              parameters.LoggerNamesToExport,
                              parameters.DiagnosticNamesToExport,

--- a/tools/code/extractor/PolicyFragment.cs
+++ b/tools/code/extractor/PolicyFragment.cs
@@ -11,11 +11,11 @@ namespace extractor;
 
 internal static class PolicyFragment
 {
-    public static async ValueTask ExportAll(ServiceDirectory serviceDirectory, ServiceUri serviceUri, IEnumerable<string>? policyFragmentNamesToExport, ListRestResources listRestResources, GetRestResource getRestResource, ILogger logger, CancellationToken cancellationToken)
+    public static async ValueTask ExportAll(ServiceDirectory serviceDirectory, ServiceUri serviceUri, IEnumerable<string>? policyFragmentNamesToExport, ListRestResources listRestResources, GetRestResource getRestResource, ILogger logger, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification, CancellationToken cancellationToken)
     {
         await List(serviceUri, listRestResources, cancellationToken)
                 .Where(policyFragmentName => ShouldExport(policyFragmentName, policyFragmentNamesToExport))
-                .ForEachParallel(async policyFragmentName => await Export(serviceDirectory, serviceUri, policyFragmentName, getRestResource, logger, cancellationToken),
+                .ForEachParallel(async policyFragmentName => await Export(serviceDirectory, serviceUri, policyFragmentName, getRestResource, logger, defaultPolicyXmlSpecification, cancellationToken),
                                  cancellationToken);
     }
 
@@ -32,13 +32,13 @@ internal static class PolicyFragment
                || policyFragmentNamesToExport.Any(policyFragmentNameToExport => policyFragmentNameToExport.Equals(policyFragmentName.ToString(), StringComparison.OrdinalIgnoreCase));
     }
 
-    private static async ValueTask Export(ServiceDirectory serviceDirectory, ServiceUri serviceUri, PolicyFragmentName policyFragmentName, GetRestResource getRestResource, ILogger logger, CancellationToken cancellationToken)
+    private static async ValueTask Export(ServiceDirectory serviceDirectory, ServiceUri serviceUri, PolicyFragmentName policyFragmentName, GetRestResource getRestResource, ILogger logger, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification, CancellationToken cancellationToken)
     {
         var policyFragmentsDirectory = new PolicyFragmentsDirectory(serviceDirectory);
         var policyFragmentDirectory = new PolicyFragmentDirectory(policyFragmentName, policyFragmentsDirectory);
 
         var policyFragmentsUri = new PolicyFragmentsUri(serviceUri);
-        var policyFragmentUri = new PolicyFragmentUri(policyFragmentName, policyFragmentsUri);
+        var policyFragmentUri = new PolicyFragmentUri(policyFragmentName, policyFragmentsUri, defaultPolicyXmlSpecification);
         var policyFragmentJson = await getRestResource(policyFragmentUri.Uri, cancellationToken);
 
         await ExportInformationFile(policyFragmentDirectory, policyFragmentName, policyFragmentJson, logger, cancellationToken);

--- a/tools/code/extractor/ProductPolicy.cs
+++ b/tools/code/extractor/ProductPolicy.cs
@@ -9,10 +9,10 @@ namespace extractor;
 
 internal static class ProductPolicy
 {
-    public static async ValueTask ExportAll(ProductDirectory productDirectory, ProductUri productUri, ListRestResources listRestResources, GetRestResource getRestResource, ILogger logger, CancellationToken cancellationToken)
+    public static async ValueTask ExportAll(ProductDirectory productDirectory, ProductUri productUri, ListRestResources listRestResources, GetRestResource getRestResource, ILogger logger, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification, CancellationToken cancellationToken)
     {
         await List(productUri, listRestResources, cancellationToken)
-                .ForEachParallel(async policyName => await Export(productDirectory, productUri, policyName, getRestResource, logger, cancellationToken),
+                .ForEachParallel(async policyName => await Export(productDirectory, productUri, policyName, getRestResource, logger, defaultPolicyXmlSpecification, cancellationToken),
                                  cancellationToken);
     }
 
@@ -24,12 +24,12 @@ internal static class ProductPolicy
                                 .Select(name => new ProductPolicyName(name));
     }
 
-    private static async ValueTask Export(ProductDirectory productDirectory, ProductUri productUri, ProductPolicyName policyName, GetRestResource getRestResource, ILogger logger, CancellationToken cancellationToken)
+    private static async ValueTask Export(ProductDirectory productDirectory, ProductUri productUri, ProductPolicyName policyName, GetRestResource getRestResource, ILogger logger, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification, CancellationToken cancellationToken)
     {
         var policyFile = new ProductPolicyFile(policyName, productDirectory);
 
         var policiesUri = new ProductPoliciesUri(productUri);
-        var policyUri = new ProductPolicyUri(policyName, policiesUri);
+        var policyUri = new ProductPolicyUri(policyName, policiesUri, defaultPolicyXmlSpecification);
         var responseJson = await getRestResource(policyUri.Uri, cancellationToken);
         var policyContent = responseJson.GetJsonObjectProperty("properties")
                                         .GetStringProperty("value");

--- a/tools/code/extractor/Program.cs
+++ b/tools/code/extractor/Program.cs
@@ -192,6 +192,7 @@ public static class Program
             SubscriptionNamesToExport = GetSubscriptionNamesToExport(configuration),
             PolicyFragmentNamesToExport = GetPolicyFragmentNamesToExport(configuration),
             DefaultApiSpecification = GetApiSpecification(configuration),
+            DefaultPolicyXmlSpecification = GetDefaultXmlPolicySpecification(configuration),
             ApplicationLifetime = provider.GetRequiredService<IHostApplicationLifetime>(),
             DownloadResource = provider.GetRequiredService<DownloadResource>(),
             GetRestResource = provider.GetRequiredService<GetRestResource>(),
@@ -200,6 +201,21 @@ public static class Program
             ServiceDirectory = GetServiceDirectory(configuration),
             ServiceUri = GetServiceUri(configuration, armEnvironment)
         };
+    }
+
+    private static DefaultPolicyXmlSpecification GetDefaultXmlPolicySpecification(IConfiguration configuration)
+    {
+        var configurationFormat = configuration.TryGetValue("POLICY_SPECIFICATION_FORMAT")
+                                  ?? configuration.TryGetValue("policySpecificationFormat");
+
+        return configurationFormat is null
+            ? new DefaultPolicyXmlSpecification.RawXmlFormat() as DefaultPolicyXmlSpecification
+            : configurationFormat switch
+            {
+                _ when configurationFormat.Equals("RawXML", StringComparison.OrdinalIgnoreCase) => new DefaultPolicyXmlSpecification.RawXmlFormat(),
+                _ when configurationFormat.Equals("XML", StringComparison.OrdinalIgnoreCase) => new DefaultPolicyXmlSpecification.XmlFormat(),
+                _ => throw new InvalidOperationException($"Policy specification format '{configurationFormat}' defined in configuration is not supported.")
+            };
     }
 
     private static IEnumerable<string>? GetApiNamesToExport(IConfiguration configuration)

--- a/tools/code/extractor/Service.cs
+++ b/tools/code/extractor/Service.cs
@@ -12,6 +12,7 @@ internal static class Service
         ServiceDirectory serviceDirectory,
         ServiceUri serviceUri,
         DefaultApiSpecification defaultSpecification,
+        DefaultPolicyXmlSpecification defaultPolicyXmlSpecification,
         IEnumerable<string>? apiNamesToExport,
         IEnumerable<string>? loggerNamesToExport,
         IEnumerable<string>? diagnosticNamesToExport,
@@ -46,19 +47,19 @@ internal static class Service
         await Backend.ExportAll(serviceDirectory, serviceUri, listRestResources, getRestResource, logger, backendNamesToExport, cancellationToken);
 
         logger.LogInformation("Exporting products...");
-        await Product.ExportAll(serviceDirectory, serviceUri, apiNamesToExport, listRestResources, getRestResource, logger, productNamesToExport, cancellationToken);
+        await Product.ExportAll(serviceDirectory, serviceUri, apiNamesToExport, listRestResources, getRestResource, logger, productNamesToExport, defaultPolicyXmlSpecification, cancellationToken);
 
         logger.LogInformation("Exporting gateways...");
         await Gateway.ExportAll(serviceDirectory, serviceUri, apiNamesToExport, listRestResources, getRestResource, logger, cancellationToken);
 
         logger.LogInformation("Exporting policy fragments...");
-        await PolicyFragment.ExportAll(serviceDirectory, serviceUri, policyFragmentNamesToExport, listRestResources, getRestResource, logger, cancellationToken);
+        await PolicyFragment.ExportAll(serviceDirectory, serviceUri, policyFragmentNamesToExport, listRestResources, getRestResource, logger, defaultPolicyXmlSpecification, cancellationToken);
 
         logger.LogInformation("Exporting service policies...");
-        await ServicePolicy.ExportAll(serviceUri, serviceDirectory, listRestResources, getRestResource, logger, cancellationToken);
+        await ServicePolicy.ExportAll(serviceUri, serviceDirectory, listRestResources, getRestResource, logger, defaultPolicyXmlSpecification, cancellationToken);
 
         logger.LogInformation("Exporting apis...");
-        await Api.ExportAll(serviceDirectory, serviceUri, defaultSpecification, apiNamesToExport, listRestResources, getRestResource, downloadResource, logger, cancellationToken);
+        await Api.ExportAll(serviceDirectory, serviceUri, defaultSpecification, apiNamesToExport, listRestResources, getRestResource, downloadResource, logger, defaultPolicyXmlSpecification, cancellationToken);
 
         logger.LogInformation("Exporting subscriptions...");
         await Subscription.ExportAll(serviceDirectory, serviceUri, listRestResources, getRestResource, logger, subscriptionNamesToExport, cancellationToken);

--- a/tools/code/extractor/ServicePolicy.cs
+++ b/tools/code/extractor/ServicePolicy.cs
@@ -9,10 +9,10 @@ namespace extractor;
 
 internal static class ServicePolicy
 {
-    public static async ValueTask ExportAll(ServiceUri serviceUri, ServiceDirectory serviceDirectory, ListRestResources listRestResources, GetRestResource getRestResource, ILogger logger, CancellationToken cancellationToken)
+    public static async ValueTask ExportAll(ServiceUri serviceUri, ServiceDirectory serviceDirectory, ListRestResources listRestResources, GetRestResource getRestResource, ILogger logger, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification, CancellationToken cancellationToken)
     {
         await List(serviceUri, listRestResources, cancellationToken)
-                .ForEachParallel(async policyName => await Export(serviceDirectory, serviceUri, policyName, getRestResource, logger, cancellationToken),
+                .ForEachParallel(async policyName => await Export(serviceDirectory, serviceUri, policyName, getRestResource, logger, defaultPolicyXmlSpecification, cancellationToken),
                                  cancellationToken);
     }
 
@@ -24,12 +24,12 @@ internal static class ServicePolicy
                                 .Select(name => new ServicePolicyName(name));
     }
 
-    private static async ValueTask Export(ServiceDirectory serviceDirectory, ServiceUri serviceUri, ServicePolicyName policyName, GetRestResource getRestResource, ILogger logger, CancellationToken cancellationToken)
+    private static async ValueTask Export(ServiceDirectory serviceDirectory, ServiceUri serviceUri, ServicePolicyName policyName, GetRestResource getRestResource, ILogger logger, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification, CancellationToken cancellationToken)
     {
         var policyFile = new ServicePolicyFile(policyName, serviceDirectory);
 
         var policiesUri = new ServicePoliciesUri(serviceUri);
-        var policyUri = new ServicePolicyUri(policyName, policiesUri);
+        var policyUri = new ServicePolicyUri(policyName, policiesUri, defaultPolicyXmlSpecification);
         var responseJson = await getRestResource(policyUri.Uri, cancellationToken);
         var policyContent = responseJson.GetJsonObjectProperty("properties")
                                         .GetStringProperty("value");

--- a/tools/code/publisher/Program.cs
+++ b/tools/code/publisher/Program.cs
@@ -207,6 +207,7 @@ public static class Program
             CommitId = TryGetCommitId(configuration),
             ConfigurationFile = TryGetConfigurationFile(configuration),
             ConfigurationJson = GetConfigurationJson(configuration),
+            DefaultPolicyXmlSpecification = GetDefaultXmlPolicySpecification(configuration),
             DeleteRestResource = provider.GetRequiredService<DeleteRestResource>(),
             ListRestResources = provider.GetRequiredService<ListRestResources>(),
             GetRestResource = provider.GetRequiredService<GetRestResource>(),
@@ -215,6 +216,21 @@ public static class Program
             ServiceDirectory = GetServiceDirectory(configuration),
             ServiceUri = GetServiceUri(configuration, armEnvironment)
         };
+    }
+
+    private static DefaultPolicyXmlSpecification GetDefaultXmlPolicySpecification(IConfiguration configuration)
+    {
+        var configurationFormat = configuration.TryGetValue("POLICY_SPECIFICATION_FORMAT")
+                                  ?? configuration.TryGetValue("policySpecificationFormat");
+
+        return configurationFormat is null
+            ? new DefaultPolicyXmlSpecification.RawXmlFormat() as DefaultPolicyXmlSpecification
+            : configurationFormat switch
+            {
+                _ when configurationFormat.Equals("RawXML", StringComparison.OrdinalIgnoreCase) => new DefaultPolicyXmlSpecification.RawXmlFormat(),
+                _ when configurationFormat.Equals("XML", StringComparison.OrdinalIgnoreCase) => new DefaultPolicyXmlSpecification.XmlFormat(),
+                _ => throw new InvalidOperationException($"Policy specification format '{configurationFormat}' defined in configuration is not supported.")
+            };
     }
 
     private static CommitId? TryGetCommitId(IConfiguration configuration)

--- a/tools/code/publisher/Publisher.cs
+++ b/tools/code/publisher/Publisher.cs
@@ -28,6 +28,7 @@ internal class Publisher : BackgroundService
         public required PutRestResource PutRestResource { get; init; }
         public required ServiceDirectory ServiceDirectory { get; init; }
         public required ServiceUri ServiceUri { get; init; }
+        public required DefaultPolicyXmlSpecification DefaultPolicyXmlSpecification { get; init; }
     }
 
     private readonly Parameters publisherParameters;
@@ -90,6 +91,7 @@ internal class Publisher : BackgroundService
                                             publisherParameters.GetRestResource,
                                             publisherParameters.PutRestResource,
                                             publisherParameters.DeleteRestResource,
+                                            publisherParameters.DefaultPolicyXmlSpecification,
                                             logger,
                                             cancellationToken);
     }
@@ -146,6 +148,7 @@ internal class Publisher : BackgroundService
                                               publisherParameters.GetRestResource,
                                               publisherParameters.PutRestResource,
                                               publisherParameters.DeleteRestResource,
+                                              publisherParameters.DefaultPolicyXmlSpecification,
                                               publisherParameters.Logger,
                                               cancellationToken);
     }
@@ -160,6 +163,7 @@ internal class Publisher : BackgroundService
                                             publisherParameters.GetRestResource,
                                             publisherParameters.PutRestResource,
                                             publisherParameters.DeleteRestResource,
+                                            publisherParameters.DefaultPolicyXmlSpecification,
                                             publisherParameters.Logger,
                                             cancellationToken);
     }

--- a/tools/code/publisher/Service.cs
+++ b/tools/code/publisher/Service.cs
@@ -10,11 +10,11 @@ namespace publisher;
 
 internal static class Service
 {
-    public static async ValueTask ProcessDeletedArtifacts(IReadOnlyCollection<FileInfo> files, JsonObject configurationJson, ServiceDirectory serviceDirectory, ServiceUri serviceUri, ListRestResources listRestResources, GetRestResource getRestResource, PutRestResource putRestResource, DeleteRestResource deleteRestResource, ILogger logger, CancellationToken cancellationToken)
+    public static async ValueTask ProcessDeletedArtifacts(IReadOnlyCollection<FileInfo> files, JsonObject configurationJson, ServiceDirectory serviceDirectory, ServiceUri serviceUri, ListRestResources listRestResources, GetRestResource getRestResource, PutRestResource putRestResource, DeleteRestResource deleteRestResource, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification, ILogger logger, CancellationToken cancellationToken)
     {
         await GatewayApi.ProcessDeletedArtifacts(files, configurationJson, serviceDirectory, serviceUri, listRestResources, putRestResource, deleteRestResource, logger, cancellationToken);
         await ProductApi.ProcessDeletedArtifacts(files, configurationJson, serviceDirectory, serviceUri, listRestResources, putRestResource, deleteRestResource, logger, cancellationToken);
-        await ApiOperationPolicy.ProcessDeletedArtifacts(files, serviceDirectory, serviceUri, deleteRestResource, logger, cancellationToken);
+        await ApiOperationPolicy.ProcessDeletedArtifacts(files, serviceDirectory, serviceUri, deleteRestResource, logger,  cancellationToken);
         await ApiTag.ProcessDeletedArtifacts(files, configurationJson, serviceDirectory, serviceUri, listRestResources, putRestResource, deleteRestResource, logger, cancellationToken);
         await ApiDiagnostic.ProcessDeletedArtifacts(files, serviceDirectory, serviceUri, deleteRestResource, logger, cancellationToken);
         await ApiPolicy.ProcessDeletedArtifacts(files, serviceDirectory, serviceUri, deleteRestResource, logger, cancellationToken);
@@ -25,7 +25,7 @@ internal static class Service
         await ProductPolicy.ProcessDeletedArtifacts(files, serviceDirectory, serviceUri, deleteRestResource, logger, cancellationToken);
         await Product.ProcessDeletedArtifacts(files, serviceDirectory, serviceUri, deleteRestResource, logger, cancellationToken);
         await ServicePolicy.ProcessDeletedArtifacts(files, serviceDirectory, serviceUri, deleteRestResource, logger, cancellationToken);
-        await PolicyFragment.ProcessDeletedArtifacts(files, configurationJson, serviceDirectory, serviceUri, putRestResource, deleteRestResource, logger, cancellationToken);
+        await PolicyFragment.ProcessDeletedArtifacts(files, configurationJson, serviceDirectory, serviceUri, putRestResource, deleteRestResource, logger, defaultPolicyXmlSpecification, cancellationToken);
         await Diagnostic.ProcessDeletedArtifacts(files, serviceDirectory, serviceUri, deleteRestResource, logger, cancellationToken);
         await Logger.ProcessDeletedArtifacts(files, serviceDirectory, serviceUri, deleteRestResource, logger, cancellationToken);
         await Backend.ProcessDeletedArtifacts(files, serviceDirectory, serviceUri, deleteRestResource, logger, cancellationToken);
@@ -35,7 +35,7 @@ internal static class Service
         await NamedValue.ProcessDeletedArtifacts(files, serviceDirectory, serviceUri, deleteRestResource, logger, cancellationToken);
     }
 
-    public static async ValueTask ProcessArtifactsToPut(IReadOnlyCollection<FileInfo> files, JsonObject configurationJson, ServiceDirectory serviceDirectory, ServiceUri serviceUri, ListRestResources listRestResources, GetRestResource getRestResource, PutRestResource putRestResource, DeleteRestResource deleteRestResource, ILogger logger, CancellationToken cancellationToken)
+    public static async ValueTask ProcessArtifactsToPut(IReadOnlyCollection<FileInfo> files, JsonObject configurationJson, ServiceDirectory serviceDirectory, ServiceUri serviceUri, ListRestResources listRestResources, GetRestResource getRestResource, PutRestResource putRestResource, DeleteRestResource deleteRestResource, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification, ILogger logger, CancellationToken cancellationToken)
     {
         await NamedValue.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, putRestResource, logger, cancellationToken);
         await Tag.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, putRestResource, logger, cancellationToken);
@@ -44,17 +44,17 @@ internal static class Service
         await Backend.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, putRestResource, logger, cancellationToken);
         await Logger.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, putRestResource, logger, cancellationToken);
         await Diagnostic.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, putRestResource, logger, cancellationToken);
-        await PolicyFragment.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, putRestResource, logger, cancellationToken);
-        await ServicePolicy.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, putRestResource, logger, cancellationToken);
+        await PolicyFragment.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, putRestResource, logger, defaultPolicyXmlSpecification, cancellationToken);
+        await ServicePolicy.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, putRestResource, logger, defaultPolicyXmlSpecification, cancellationToken);
         await Product.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, putRestResource, logger, cancellationToken);
-        await ProductPolicy.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, putRestResource, logger, cancellationToken);
+        await ProductPolicy.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, putRestResource, logger, defaultPolicyXmlSpecification, cancellationToken);
         await ProductGroup.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, listRestResources, putRestResource, deleteRestResource, logger, cancellationToken);
         await ProductTag.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, listRestResources, putRestResource, deleteRestResource, logger, cancellationToken);
         await Api.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, getRestResource, putRestResource, logger, cancellationToken);
-        await ApiPolicy.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, putRestResource, logger, cancellationToken);
+        await ApiPolicy.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, putRestResource, logger, defaultPolicyXmlSpecification, cancellationToken);
         await ApiDiagnostic.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, putRestResource, logger, cancellationToken);
         await ApiTag.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, listRestResources, putRestResource, deleteRestResource, logger, cancellationToken);
-        await ApiOperationPolicy.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, putRestResource, logger, cancellationToken);
+        await ApiOperationPolicy.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, putRestResource, logger, defaultPolicyXmlSpecification, cancellationToken);
         await ProductApi.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, listRestResources, putRestResource, deleteRestResource, logger, cancellationToken);
         await GatewayApi.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, listRestResources, putRestResource, deleteRestResource, logger, cancellationToken);
         await Subscription.ProcessArtifactsToPut(files, configurationJson, serviceDirectory, serviceUri, putRestResource, logger, cancellationToken);

--- a/tools/code/publisher/ServicePolicy.cs
+++ b/tools/code/publisher/ServicePolicy.cs
@@ -49,26 +49,26 @@ internal static class ServicePolicy
     {
         logger.LogInformation("Deleting service policy {policyName}...", policyName);
 
-        var policyUri = GetServicePolicyUri(policyName, serviceUri);
+        var policyUri = GetServicePolicyUri(policyName, serviceUri, new DefaultPolicyXmlSpecification.RawXmlFormat());
         await deleteRestResource(policyUri.Uri, cancellationToken);
     }
 
-    private static ServicePolicyUri GetServicePolicyUri(ServicePolicyName policyName, ServiceUri serviceUri)
+    private static ServicePolicyUri GetServicePolicyUri(ServicePolicyName policyName, ServiceUri serviceUri, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification)
     {
         var policiesUri = new ServicePoliciesUri(serviceUri);
-        return new ServicePolicyUri(policyName, policiesUri);
+        return new ServicePolicyUri(policyName, policiesUri, defaultPolicyXmlSpecification);
     }
 
-    public static async ValueTask ProcessArtifactsToPut(IReadOnlyCollection<FileInfo> files, JsonObject configurationJson, ServiceDirectory serviceDirectory, ServiceUri serviceUri, PutRestResource putRestResource, ILogger logger, CancellationToken cancellationToken)
+    public static async ValueTask ProcessArtifactsToPut(IReadOnlyCollection<FileInfo> files, JsonObject configurationJson, ServiceDirectory serviceDirectory, ServiceUri serviceUri, PutRestResource putRestResource, ILogger logger, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification, CancellationToken cancellationToken)
     {
-        await GetArtifactsToPut(files, configurationJson, serviceDirectory, cancellationToken)
-                .ForEachParallel(async artifact => await PutPolicy(artifact.Name, artifact.Json, serviceUri, putRestResource, logger, cancellationToken),
+        await GetArtifactsToPut(files, configurationJson, serviceDirectory, defaultPolicyXmlSpecification, cancellationToken)
+                .ForEachParallel(async artifact => await PutPolicy(artifact.Name, artifact.Json, serviceUri, putRestResource, logger, defaultPolicyXmlSpecification, cancellationToken),
                                  cancellationToken);
     }
 
-    private static async IAsyncEnumerable<(ServicePolicyName Name, JsonObject Json)> GetArtifactsToPut(IReadOnlyCollection<FileInfo> files, JsonObject configurationJson, ServiceDirectory serviceDirectory, [EnumeratorCancellation] CancellationToken cancellationToken)
+    private static async IAsyncEnumerable<(ServicePolicyName Name, JsonObject Json)> GetArtifactsToPut(IReadOnlyCollection<FileInfo> files, JsonObject configurationJson, ServiceDirectory serviceDirectory, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var fileArtifacts = await GetFilePolicies(files, serviceDirectory, cancellationToken).ToListAsync(cancellationToken);
+        var fileArtifacts = await GetFilePolicies(files, serviceDirectory, defaultPolicyXmlSpecification, cancellationToken).ToListAsync(cancellationToken);
         var configurationArtifacts = GetConfigurationPolicies(configurationJson);
         var artifacts = fileArtifacts.LeftJoin(configurationArtifacts,
                                                keySelector: artifact => artifact.Name,
@@ -80,7 +80,7 @@ internal static class ServicePolicy
         }
     }
 
-    private static IAsyncEnumerable<(ServicePolicyName Name, JsonObject Json)> GetFilePolicies(IReadOnlyCollection<FileInfo> files, ServiceDirectory serviceDirectory, CancellationToken cancellationToken)
+    private static IAsyncEnumerable<(ServicePolicyName Name, JsonObject Json)> GetFilePolicies(IReadOnlyCollection<FileInfo> files, ServiceDirectory serviceDirectory, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification, CancellationToken cancellationToken)
     {
         return GetPolicyFiles(files, serviceDirectory)
                 .ToAsyncEnumerable()
@@ -91,7 +91,7 @@ internal static class ServicePolicy
                     {
                         ["properties"] = new JsonObject
                         {
-                            ["format"] = "rawxml",
+                            ["format"] = defaultPolicyXmlSpecification.Format,
                             ["value"] = policyText
                         }
                     };
@@ -113,11 +113,11 @@ internal static class ServicePolicy
                                 });
     }
 
-    private static async ValueTask PutPolicy(ServicePolicyName policyName, JsonObject json, ServiceUri serviceUri, PutRestResource putRestResource, ILogger logger, CancellationToken cancellationToken)
+    private static async ValueTask PutPolicy(ServicePolicyName policyName, JsonObject json, ServiceUri serviceUri, PutRestResource putRestResource, ILogger logger, DefaultPolicyXmlSpecification defaultPolicyXmlSpecification, CancellationToken cancellationToken)
     {
         logger.LogInformation("Putting service policy {policyName}...", policyName);
 
-        var policyUri = GetServicePolicyUri(policyName, serviceUri);
+        var policyUri = GetServicePolicyUri(policyName, serviceUri, defaultPolicyXmlSpecification);
         await putRestResource(policyUri.Uri, json, cancellationToken);
     }
 }


### PR DESCRIPTION
Default value is rawxml.
I tried to maintain same approach as of now. Refactoring this to use pervasive DI would be a good maintainability improvement but out of scope for this PR.
As outline in https://github.com/Azure/apiops/issues/488 default extractor parameter is rawxml for policies file. Exported files may be read programmatically but more often than not, fails validation because of additional double quotes needed in particular instruction.
This PR adds a new parameter to choose between the two formats, default is as of today. Same parameter is added to the publisher as well. On this tool, publisher, an help with the tests would be greatly appreciated.
