### PR TITLE
Ignore ApiDiagnostics with empty loggerId after JSON transform

### DIFF
--- a/tools/code/publisher/ApiDiagnostic.cs
+++ b/tools/code/publisher/ApiDiagnostic.cs
@@ -147,7 +147,14 @@ internal static class ApiDiagnostic
 
     private static async ValueTask Put(ApiDiagnosticName diagnosticName, ApiName apiName, JsonObject json, ServiceUri serviceUri, PutRestResource putRestResource, ILogger logger, CancellationToken cancellationToken)
     {
-        logger.LogInformation("PUtting diagnostic {diagnosticName} in API {apiName}...", diagnosticName, apiName);
+        logger.LogInformation("Putting diagnostic {diagnosticName} in API {apiName}...", diagnosticName, apiName);
+
+        if (string.IsNullOrEmpty(json.TryGetProperty("properties")?.AsObject().TryGetStringProperty("loggerId")))
+        {
+            logger.LogWarning("Empty 'loggerId' found. ApiDiagnostics will be ignored.");
+
+            return;
+        }
 
         var uri = GetDiagnosticUri(diagnosticName, apiName, serviceUri);
         await putRestResource(uri.Uri, json, cancellationToken);


### PR DESCRIPTION
**Scenario:**
Use the JSON transform capabilities to transform a loggerId to an empty value in order to disable the API logger in a higher environment, but have it still in the repository for the lower environment.

configuration.env.yaml example:
```
apis:
  - name: petstore-api    
    diagnostics:
      - name: applicationinsights
        properties:
          loggerId: ''
```
_The result is an empty string value for the loggerId field in the JSON payload_

**PR Changes:**
When an empty values is found for the required loggerId value for the API call, the call is not executed and a warning is logged instead.