### PR TITLE
Warn, don't fail, when an API is not found when publishing an API product

### DIFF
--- a/tools/code/publisher/ProductApi.cs
+++ b/tools/code/publisher/ProductApi.cs
@@ -192,7 +192,7 @@ internal static class ProductApi
                 else
                 {
                     // Retry limit reached, log as warning
-                    logger.LogWarning("API {apiName} not found, the API will not be added to product in the target environment.", apiName);
+                    logger.LogWarning("API {apiName} not found, the API is NOT added to product in the target environment.", apiName);
 
                     // End retry without exception
                     return;

--- a/tools/code/publisher/ProductApi.cs
+++ b/tools/code/publisher/ProductApi.cs
@@ -181,9 +181,19 @@ internal static class ProductApi
             }
             catch (HttpRequestException httpRequestException) when (httpRequestException.Message.Contains("API not found"))
             {
-                logger.LogWarning("API not found, the API will not be added to the Product.");
-
-                return;
+                retryCount++;
+                if (retryCount <= 3)
+                {
+                    // Log the retry attempt
+                    logger.LogWarning("Retrying API put operation for {apiName}. Retry attempt: {retryCount}", apiName, retryCount);
+                    // Wait for a certain duration before retrying
+                    await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, retryCount)), cancellationToken);
+                }
+                else
+                {
+                    // Retry limit reached, log as warning
+                    logger.LogWarning("API {apiName} not found, the API will not be added to product in the target environment.", apiName);
+                }
             }
         }
     }

--- a/tools/code/publisher/ProductApi.cs
+++ b/tools/code/publisher/ProductApi.cs
@@ -179,6 +179,12 @@ internal static class ProductApi
                     throw;
                 }
             }
+            catch (HttpRequestException httpRequestException) when (httpRequestException.Message.Contains("API not found"))
+            {
+                logger.LogWarning("API not found, the API will not be added to the Product.");
+
+                return;
+            }
         }
     }
 

--- a/tools/code/publisher/ProductApi.cs
+++ b/tools/code/publisher/ProductApi.cs
@@ -193,6 +193,9 @@ internal static class ProductApi
                 {
                     // Retry limit reached, log as warning
                     logger.LogWarning("API {apiName} not found, the API will not be added to product in the target environment.", apiName);
+
+                    // End retry without exception
+                    return;
                 }
             }
         }


### PR DESCRIPTION
**Scenario:**
- ApiOps is used in a MultiRepo setup (~multiple independant teams)
- API Products are managed & published in the central team repo
- APIs are managed by the teams

When an API product is published to a higher environment, where the API itself does not exists yet, the deployment of the API Product fails the publish process.

**PR Changes:**
Catch the "API Not Found" exception when publishing an API Product and log a warning instead of throwing an exception.