### PR TITLE
Use latest version AzDo replacetokens task

### DIFF
--- a/tools/azdo_pipelines/run-publisher-with-env.yaml
+++ b/tools/azdo_pipelines/run-publisher-with-env.yaml
@@ -63,9 +63,9 @@ steps:
       addSpnToEnvironment: true
       failOnStandardError: true
 
-  # replacetokens@3 task will need to be installed to use
+  # replacetokens@6 task will need to be installed to use
   - ${{ if ne(parameters.CONFIGURATION_YAML_PATH, '') }}:
-      - task: qetza.replacetokens.replacetokens-task.replacetokens@3
+      - task: qetza.replacetokens.replacetokens-task.replacetokens@6
         displayName: "Perform namevalue secret substitution in ${{ parameters.CONFIGURATION_YAML_PATH }}"
         inputs:
           targetFiles: ${{ parameters.CONFIGURATION_YAML_PATH }}


### PR DESCRIPTION
Update to version 6 of the AzDo replace tokens task.
Version 3 is marked as deprecated.