### PR TITLE
Add GitHub least permissions for run extractor workflow

### DIFF
--- a/tools/github_workflows/run-extractor.yaml
+++ b/tools/github_workflows/run-extractor.yaml
@@ -154,6 +154,10 @@ jobs:
   create-pull-request:
     needs: extract
     runs-on: [ubuntu-latest]
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@v4
           


### PR DESCRIPTION
The workflow has multiple jobs. The `create-pull-request` job needs to have permissions to:
- write contents (new branch and push the items to the branch)
- write pull-requests (need to create the pull request for the branch)
- write issues (needs to have these permissions to create labels on the pull request)