### PR TITLE
Warn, don't fail, when an API is not found when publishing an API product

### DIFF
--- a/tools/code/publisher/ProductApi.cs
+++ b/tools/code/publisher/ProductApi.cs
@@ -9,6 +9,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -164,8 +165,13 @@ internal static class ProductApiModule
         {
             logger.LogInformation("Adding API {ApiName} to product {ProductName}...", name, productName);
 
-            await ProductApiUri.From(name, productName, serviceUri)
-                               .PutDto(dto, pipeline, cancellationToken);
+            try {
+                await ProductApiUri.From(name, productName, serviceUri)
+                                   .PutDto(dto, pipeline, cancellationToken);
+            } catch (HttpRequestException httpRequestException) when (httpRequestException.Message.Contains("API not found", StringComparison.OrdinalIgnoreCase)){
+                logger.LogWarning("API {ApiName} not found, the API is NOT added to product in the target environment.", name);
+                return;
+            }
         };
     }
 


### PR DESCRIPTION
**Scenario:**

ApiOps is used in a MultiRepo setup (~multiple independant teams)
API Products are managed & published in the central team repo
APIs are managed by the teams
When an API product is published to a higher environment, where the API itself does not exists yet, the deployment of the API Product fails the publish process.

**PR Changes:**
Catch the "API Not Found" exception when publishing an API Product and log a warning instead of throwing an exception.

This PR is the V6 version of #531