### PR TITLE
Only Run Workflow on Push, not PR Close

### DIFF
--- a/tools/github_workflows/run-publisher.yaml
+++ b/tools/github_workflows/run-publisher.yaml
@@ -1,10 +1,9 @@
 name: Run - Publisher
 
 on:
-  # Triggers the workflow on pull request events but only for the main branch
-  pull_request:
+  # Triggers the workflow on push events but only for the main branch
+  push:
     branches: [main]
-    types: [closed]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
`closed` `pull_request` events trigger the workflow even if the PR is manually closed and not merged.