### PR TITLE
Add retry logic for 409 response with specific Conflict error code

### DIFF
--- a/tools/code/common/Http.cs
+++ b/tools/code/common/Http.cs
@@ -402,6 +402,7 @@ public class CommonRetryPolicy : RetryPolicy
                 (message, exception) switch
                 {
                     ({ Response.Status: 422 or 409 }, _) when HasManagementApiRequestFailedError(message.Response) => true,
+                    ({ Response.Status: 409 }, _) when HasConflictError(message.Response) => true,
                     ({ Response.Status: 412 }, _) => true,
                     ({ Response.Status: 429 }, _) => true,
                     _ => false
@@ -416,6 +417,11 @@ public class CommonRetryPolicy : RetryPolicy
     private static bool HasManagementApiRequestFailedError(Response response) =>
         TryGetErrorCode(response)
             .Where(code => code.Equals("ManagementApiRequestFailed", StringComparison.OrdinalIgnoreCase))
+            .IsSome;
+
+    private static bool HasConflictError(Response response) =>
+        TryGetErrorCode(response)
+            .Where(code => code.Equals("Conflict", StringComparison.OrdinalIgnoreCase))
             .IsSome;
 
     private static Option<string> TryGetErrorCode(Response response)

--- a/tools/code/common/Http.cs
+++ b/tools/code/common/Http.cs
@@ -402,7 +402,7 @@ public class CommonRetryPolicy : RetryPolicy
                 (message, exception) switch
                 {
                     ({ Response.Status: 422 or 409 }, _) when HasManagementApiRequestFailedError(message.Response) => true,
-                    ({ Response.Status: 409 }, _) when HasConflictError(message.Response) => true,
+                    ({ Response.Status: 409 }, _) when HasConflictError(message.Response) && HasOperationOnTheApiIsInProgressMessage(message.Response) => true,
                     ({ Response.Status: 412 }, _) => true,
                     ({ Response.Status: 429 }, _) => true,
                     _ => false
@@ -424,6 +424,11 @@ public class CommonRetryPolicy : RetryPolicy
             .Where(code => code.Equals("Conflict", StringComparison.OrdinalIgnoreCase))
             .IsSome;
 
+    private static bool HasOperationOnTheApiIsInProgressMessage(Response response) =>
+        TryGetMessage(response)
+            .Where(code => code.Equals("Operation on the API is in progress", StringComparison.OrdinalIgnoreCase))
+            .IsSome;
+
     private static Option<string> TryGetErrorCode(Response response)
     {
         try
@@ -432,6 +437,22 @@ public class CommonRetryPolicy : RetryPolicy
                            .ToObjectFromJson<JsonObject>()
                            .TryGetJsonObjectProperty("error")
                            .Bind(error => error.TryGetStringProperty("code"))
+                           .ToOption();
+        }
+        catch (Exception exception) when (exception is ArgumentNullException or NotSupportedException or JsonException)
+        {
+            return Option<string>.None;
+        }
+    }
+
+    private static Option<string> TryGetMessage(Response response)
+    {
+        try
+        {
+            return response.Content
+                           .ToObjectFromJson<JsonObject>()
+                           .TryGetJsonObjectProperty("error")
+                           .Bind(error => error.TryGetStringProperty("message"))
                            .ToOption();
         }
         catch (Exception exception) when (exception is ArgumentNullException or NotSupportedException or JsonException)


### PR DESCRIPTION
The 422 and 409 errors are retried in combination with the `ManagementApiRequestFailed` error code as discussed in issue #497.
In our case, the publisher is failing randomly on an API with a response that is not handled in the retry policy.

Sample response:
`Content: {"error":{"code":"Conflict","message":"Operation on the API is in progress","details":null}}`.

This pull request improves the retry logic for HTTP requests in `tools/code/common/Http.cs`, specifically for handling certain API conflict scenarios. The main change is to add more granular checks for when a retry should occur, particularly for 409 Conflict responses related to ongoing API operations.

**Enhanced retry logic for HTTP requests:**

* Added a new condition to `ShouldRetryInner` to retry when a 409 Conflict response has both the "Conflict" error code and the "Operation on the API is in progress" message.

**New helper methods for response inspection:**

* Implemented `HasConflictError` to check if the response error code is "Conflict".
* Implemented `HasOperationOnTheApiIsInProgressMessage` to check if the response error message is "Operation on the API is in progress".
* Added `TryGetMessage` to extract the error message from the response JSON.

These changes make the retry logic more robust and specific, reducing unnecessary retries and better handling API concurrency scenarios.