### PR TITLE
Fix 'PessimisticConcurrencyConflict' next to 'Conflict' error codes

### DIFF
--- a/tools/code/common/Http.cs
+++ b/tools/code/common/Http.cs
@@ -402,7 +402,7 @@ public class CommonRetryPolicy : RetryPolicy
                 (message, exception) switch
                 {
                     ({ Response.Status: 422 or 409 }, _) when HasManagementApiRequestFailedError(message.Response) => true,
-                    ({ Response.Status: 409 }, _) when HasConflictError(message.Response) && HasOperationOnTheApiIsInProgressMessage(message.Response) => true,
+                    ({ Response.Status: 409 }, _) when HasConflictOrPessimisticConcurrencyConflictError(message.Response) && HasOperationOnTheApiIsInProgressMessage(message.Response) => true,
                     ({ Response.Status: 412 }, _) => true,
                     ({ Response.Status: 429 }, _) => true,
                     _ => false
@@ -419,9 +419,12 @@ public class CommonRetryPolicy : RetryPolicy
             .Where(code => code.Equals("ManagementApiRequestFailed", StringComparison.OrdinalIgnoreCase))
             .IsSome;
 
-    private static bool HasConflictError(Response response) =>
+    private static bool HasConflictOrPessimisticConcurrencyConflictError(Response response) =>
         TryGetErrorCode(response)
-            .Where(code => code.Equals("Conflict", StringComparison.OrdinalIgnoreCase))
+            .Where(code => 
+                code.Equals("Conflict", StringComparison.OrdinalIgnoreCase) ||
+                code.Equals("PessimisticConcurrencyConflict", StringComparison.OrdinalIgnoreCase)
+            )
             .IsSome;
 
     private static bool HasOperationOnTheApiIsInProgressMessage(Response response) =>


### PR DESCRIPTION
In [PR 787](https://github.com/Azure/apiops/pull/787) we added a retry for 409 conflict errors.
We now get almost the same error so I added an "or" statement.

We get the following error:
`{"error":{"code":"PessimisticConcurrencyConflict","message":"Operation on the API is in progress","details":null}}`

This pull request updates the HTTP retry logic to handle an additional error scenario related to concurrency conflicts. The main focus is on improving the robustness of retry decisions when a 409 response status is encountered.

**Improvements to error handling and retry logic:**

* The helper method previously named `HasConflictError` has been renamed to `HasConflictOrPessimisticConcurrencyConflictError`, and its logic expanded to check for both `Conflict` and `PessimisticConcurrencyConflict` error codes in the response.