### PR TITLE
v7 Add enhanced retry logic for HTTP 409 conflict errors

### DIFF
--- a/tools/code/common/Http.cs
+++ b/tools/code/common/Http.cs
@@ -402,6 +402,7 @@ public class CommonRetryPolicy : RetryPolicy
                 (message, exception) switch
                 {
                     ({ Response.Status: 422 or 409 }, _) when HasManagementApiRequestFailedError(message.Response) => true,
+                    ({ Response.Status: 409 }, _) when HasConflictOrPessimisticConcurrencyConflictError(message.Response) && HasOperationOnTheApiIsInProgressMessage(message.Response) => true,
                     ({ Response.Status: 412 }, _) => true,
                     ({ Response.Status: 429 }, _) => true,
                     _ => false
@@ -418,6 +419,19 @@ public class CommonRetryPolicy : RetryPolicy
             .Where(code => code.Equals("ManagementApiRequestFailed", StringComparison.OrdinalIgnoreCase))
             .IsSome;
 
+    private static bool HasConflictOrPessimisticConcurrencyConflictError(Response response) =>
+        TryGetErrorCode(response)
+            .Where(code =>
+                code.Equals("Conflict", StringComparison.OrdinalIgnoreCase) ||
+                code.Equals("PessimisticConcurrencyConflict", StringComparison.OrdinalIgnoreCase)
+            )
+            .IsSome;
+
+    private static bool HasOperationOnTheApiIsInProgressMessage(Response response) =>
+        TryGetMessage(response)
+            .Where(code => code.Equals("Operation on the API is in progress", StringComparison.OrdinalIgnoreCase))
+            .IsSome;
+
     private static Option<string> TryGetErrorCode(Response response)
     {
         try
@@ -426,6 +440,22 @@ public class CommonRetryPolicy : RetryPolicy
                            .ToObjectFromJson<JsonObject>()
                            .TryGetJsonObjectProperty("error")
                            .Bind(error => error.TryGetStringProperty("code"))
+                           .ToOption();
+        }
+        catch (Exception exception) when (exception is ArgumentNullException or NotSupportedException or JsonException)
+        {
+            return Option<string>.None;
+        }
+    }
+
+    private static Option<string> TryGetMessage(Response response)
+    {
+        try
+        {
+            return response.Content
+                           .ToObjectFromJson<JsonObject>()
+                           .TryGetJsonObjectProperty("error")
+                           .Bind(error => error.TryGetStringProperty("message"))
                            .ToOption();
         }
         catch (Exception exception) when (exception is ArgumentNullException or NotSupportedException or JsonException)


### PR DESCRIPTION
In previous [PR 787](https://github.com/Azure/apiops/pull/787) for v6 we added retry logic for Conflict error. That PR is apparantly not merged to v7 but was also not sufficient because of the missing `PessimisticConcurrencyConflict` error. See [PR 799](https://github.com/Azure/apiops/pull/799) for more information for the v6 implementation.

**Details:**

Enhanced the retry logic to handle HTTP 409 responses more robustly by checking for specific error codes ("Conflict" or "PessimisticConcurrencyConflict") and messages ("Operation on the API is in progress").

Added `HasConflictOrPessimisticConcurrencyConflictError` and `HasOperationOnTheApiIsInProgressMessage` helper methods to encapsulate these checks. Introduced `TryGetMessage` to safely extract the "message" property from JSON responses, with improved error handling for parsing failures.

Refactored code to improve readability and maintainability by modularizing retry condition checks.