### PR TITLE
Add support for large language model diagnostics in API and common modules

### DIFF
--- a/tools/code/common.tests/ApiDiagnostic.cs
+++ b/tools/code/common.tests/ApiDiagnostic.cs
@@ -25,12 +25,46 @@ public sealed record ApiDiagnosticSampling
         };
 }
 
+public sealed record ApiDiagnosticLargeLanguageModelMessages
+{
+    public required string Messages { get; init; }
+    public required int MaxSizeInBytes { get; init; }
+
+    public static Gen<ApiDiagnosticLargeLanguageModelMessages> Generate() =>
+        from messages in Gen.OneOfConst("all", "errors")
+        from maxSize in Gen.Int[0, 65536]
+        select new ApiDiagnosticLargeLanguageModelMessages
+        {
+            Messages = messages,
+            MaxSizeInBytes = maxSize
+        };
+}
+
+public sealed record ApiDiagnosticLargeLanguageModel
+{
+    public Option<string> Logs { get; init; }
+    public Option<ApiDiagnosticLargeLanguageModelMessages> Requests { get; init; }
+    public Option<ApiDiagnosticLargeLanguageModelMessages> Responses { get; init; }
+
+    public static Gen<ApiDiagnosticLargeLanguageModel> Generate() =>
+        from logs in Gen.OneOfConst("enabled", "disabled").OptionOf()
+        from requests in ApiDiagnosticLargeLanguageModelMessages.Generate().OptionOf()
+        from responses in ApiDiagnosticLargeLanguageModelMessages.Generate().OptionOf()
+        select new ApiDiagnosticLargeLanguageModel
+        {
+            Logs = logs,
+            Requests = requests,
+            Responses = responses
+        };
+}
+
 public record ApiDiagnosticModel
 {
     public required ApiDiagnosticName Name { get; init; }
     public required LoggerName LoggerName { get; init; }
     public Option<string> AlwaysLog { get; init; }
     public Option<ApiDiagnosticSampling> Sampling { get; init; }
+    public Option<ApiDiagnosticLargeLanguageModel> LargeLanguageModel { get; init; }
 
     public static Gen<ApiDiagnosticModel> Generate() =>
         from loggerType in LoggerType.Generate()
@@ -38,12 +72,14 @@ public record ApiDiagnosticModel
         from name in GenerateName(loggerType)
         from alwaysLog in Gen.Const("allErrors").OptionOf()
         from sampling in ApiDiagnosticSampling.Generate().OptionOf()
+        from largeLanguageModel in ApiDiagnosticLargeLanguageModel.Generate().OptionOf()
         select new ApiDiagnosticModel
         {
             Name = name,
             LoggerName = loggerName,
             AlwaysLog = alwaysLog,
-            Sampling = sampling
+            Sampling = sampling,
+            LargeLanguageModel = largeLanguageModel
         };
 
     public static Gen<ApiDiagnosticName> GenerateName() =>

--- a/tools/code/common.tests/ApiDiagnostic.cs
+++ b/tools/code/common.tests/ApiDiagnostic.cs
@@ -94,7 +94,9 @@ public record ApiDiagnosticModel
         };
 
     public static Gen<FrozenSet<ApiDiagnosticModel>> GenerateSet() =>
-        Generate().FrozenSetOf(0, 20, Comparer);
+        from diagnostics in Generate().FrozenSetOf(0, 20, Comparer)
+        from largeLanguageModel in ApiDiagnosticLargeLanguageModel.Generate()
+        select EnsureLargeLanguageModel(diagnostics, largeLanguageModel);
 
     public static Gen<FrozenSet<ApiDiagnosticModel>> GenerateSet(FrozenSet<ApiDiagnosticModel> originalSet, ICollection<LoggerModel> loggers)
     {
@@ -113,10 +115,24 @@ public record ApiDiagnosticModel
                                                                     LoggerName = logger.Name
                                                                 })
                                           .SequenceToFrozenSet(originalSet.Comparer)
-               select updates;
+               from largeLanguageModel in ApiDiagnosticLargeLanguageModel.Generate()
+               select EnsureLargeLanguageModel(updates, largeLanguageModel);
     }
 
     private static IEqualityComparer<ApiDiagnosticModel> Comparer { get; } =
         EqualityComparerBuilder.For<ApiDiagnosticModel>()
                                .EquateBy(x => x.Name);
+
+    private static FrozenSet<ApiDiagnosticModel> EnsureLargeLanguageModel(FrozenSet<ApiDiagnosticModel> diagnostics, ApiDiagnosticLargeLanguageModel largeLanguageModel)
+    {
+        if (diagnostics.Count == 0 || diagnostics.Any(diagnostic => diagnostic.LargeLanguageModel.IsSome))
+        {
+            return diagnostics;
+        }
+
+        var diagnosticArray = diagnostics.ToArray();
+        diagnosticArray[0] = diagnosticArray[0] with { LargeLanguageModel = LanguageExt.Prelude.Some(largeLanguageModel) };
+
+        return diagnosticArray.ToFrozenSet(Comparer);
+    }
 }

--- a/tools/code/common.tests/ApiDiagnosticSerializationTests.cs
+++ b/tools/code/common.tests/ApiDiagnosticSerializationTests.cs
@@ -1,0 +1,165 @@
+﻿using common;
+using FluentAssertions;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Xunit;
+
+namespace common.tests;
+
+public class ApiDiagnosticSerializationTests
+{
+    [Fact]
+    public void ApiDiagnosticDto_Deserializes_WhenLargeLanguageModelMissing()
+    {
+        const string json = """
+        {
+          "properties": {
+            "loggerId": "/loggers/test-logger"
+          }
+        }
+        """;
+
+        var dto = JsonSerializer.Deserialize<ApiDiagnosticDto>(json, JsonObjectExtensions.SerializerOptions);
+
+        dto.Should().NotBeNull();
+        dto!.Properties.LargeLanguageModel.Should().BeNull();
+    }
+
+    [Fact]
+    public void DiagnosticDto_Deserializes_WhenLargeLanguageModelMissing()
+    {
+        const string json = """
+        {
+          "properties": {
+            "loggerId": "/loggers/test-logger"
+          }
+        }
+        """;
+
+        var dto = JsonSerializer.Deserialize<DiagnosticDto>(json, JsonObjectExtensions.SerializerOptions);
+
+        dto.Should().NotBeNull();
+        dto!.Properties.LargeLanguageModel.Should().BeNull();
+    }
+
+    [Fact]
+    public void ApiDiagnosticDto_UsesCamelCase_ForLargeLanguageModel()
+    {
+        var dto = new ApiDiagnosticDto
+        {
+            Properties = new ApiDiagnosticDto.DiagnosticContract
+            {
+                LargeLanguageModel = new ApiDiagnosticDto.LargeLanguageModelSettings
+                {
+                    Logs = "enabled",
+                    Requests = new ApiDiagnosticDto.LargeLanguageModelMessageSettings
+                    {
+                        Messages = "all",
+                        MaxSizeInBytes = 4096
+                    },
+                    Responses = new ApiDiagnosticDto.LargeLanguageModelMessageSettings
+                    {
+                        Messages = "errors",
+                        MaxSizeInBytes = 1024
+                    }
+                }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(dto, JsonObjectExtensions.SerializerOptions);
+        var node = JsonNode.Parse(json)!.AsObject();
+
+        var properties = node["properties"]!.AsObject();
+        properties.ContainsKey("largeLanguageModel").Should().BeTrue();
+
+        var llm = properties["largeLanguageModel"]!.AsObject();
+        llm.ContainsKey("logs").Should().BeTrue();
+        llm.ContainsKey("requests").Should().BeTrue();
+        llm.ContainsKey("responses").Should().BeTrue();
+
+        var requests = llm["requests"]!.AsObject();
+        requests["maxSizeInBytes"]!.GetValue<int>().Should().Be(4096);
+
+        var responses = llm["responses"]!.AsObject();
+        responses["maxSizeInBytes"]!.GetValue<int>().Should().Be(1024);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(65536)]
+    public void ApiDiagnosticDto_SerializesEdge_MaxSizeInBytes(int maxSize)
+    {
+        var dto = new ApiDiagnosticDto
+        {
+            Properties = new ApiDiagnosticDto.DiagnosticContract
+            {
+                LargeLanguageModel = new ApiDiagnosticDto.LargeLanguageModelSettings
+                {
+                    Requests = new ApiDiagnosticDto.LargeLanguageModelMessageSettings
+                    {
+                        Messages = "all",
+                        MaxSizeInBytes = maxSize
+                    },
+                    Responses = new ApiDiagnosticDto.LargeLanguageModelMessageSettings
+                    {
+                        Messages = "all",
+                        MaxSizeInBytes = maxSize
+                    }
+                }
+            }
+        };
+
+        var roundTripped = JsonSerializer.Deserialize<ApiDiagnosticDto>(
+            JsonSerializer.Serialize(dto, JsonObjectExtensions.SerializerOptions),
+            JsonObjectExtensions.SerializerOptions);
+
+        roundTripped!.Properties.LargeLanguageModel!.Requests!.MaxSizeInBytes.Should().Be(maxSize);
+        roundTripped.Properties.LargeLanguageModel!.Responses!.MaxSizeInBytes.Should().Be(maxSize);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(65536)]
+    public void DiagnosticDto_SerializesEdge_MaxSizeInBytes(int maxSize)
+    {
+        var dto = new DiagnosticDto
+        {
+            Properties = new DiagnosticDto.DiagnosticContract
+            {
+                LargeLanguageModel = new DiagnosticDto.LargeLanguageModelSettings
+                {
+                    Logs = "disabled",
+                    Requests = new DiagnosticDto.LargeLanguageModelMessageSettings
+                    {
+                        Messages = "errors",
+                        MaxSizeInBytes = maxSize
+                    },
+                    Responses = new DiagnosticDto.LargeLanguageModelMessageSettings
+                    {
+                        Messages = "all",
+                        MaxSizeInBytes = maxSize
+                    }
+                }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(dto, JsonObjectExtensions.SerializerOptions);
+        var node = JsonNode.Parse(json)!.AsObject();
+
+        var properties = node["properties"]!.AsObject();
+        properties.ContainsKey("largeLanguageModel").Should().BeTrue();
+
+        var llm = properties["largeLanguageModel"]!.AsObject();
+        llm.ContainsKey("logs").Should().BeTrue();
+        llm.ContainsKey("requests").Should().BeTrue();
+        llm.ContainsKey("responses").Should().BeTrue();
+
+        var requests = llm["requests"]!.AsObject();
+        requests["messages"]!.GetValue<string>().Should().Be("errors");
+        requests["maxSizeInBytes"]!.GetValue<int>().Should().Be(maxSize);
+
+        var responses = llm["responses"]!.AsObject();
+        responses["messages"]!.GetValue<string>().Should().Be("all");
+        responses["maxSizeInBytes"]!.GetValue<int>().Should().Be(maxSize);
+    }
+}

--- a/tools/code/common.tests/Diagnostic.cs
+++ b/tools/code/common.tests/Diagnostic.cs
@@ -20,12 +20,46 @@ public sealed record DiagnosticSampling
         };
 }
 
+public sealed record DiagnosticLargeLanguageModelMessages
+{
+    public required string Messages { get; init; }
+    public required int MaxSizeInBytes { get; init; }
+
+    public static Gen<DiagnosticLargeLanguageModelMessages> Generate() =>
+        from messages in Gen.OneOfConst("all", "errors")
+        from maxSize in Gen.Int[0, 65536]
+        select new DiagnosticLargeLanguageModelMessages
+        {
+            Messages = messages,
+            MaxSizeInBytes = maxSize
+        };
+}
+
+public sealed record DiagnosticLargeLanguageModel
+{
+    public Option<string> Logs { get; init; }
+    public Option<DiagnosticLargeLanguageModelMessages> Requests { get; init; }
+    public Option<DiagnosticLargeLanguageModelMessages> Responses { get; init; }
+
+    public static Gen<DiagnosticLargeLanguageModel> Generate() =>
+        from logs in Gen.OneOfConst("enabled", "disabled").OptionOf()
+        from requests in DiagnosticLargeLanguageModelMessages.Generate().OptionOf()
+        from responses in DiagnosticLargeLanguageModelMessages.Generate().OptionOf()
+        select new DiagnosticLargeLanguageModel
+        {
+            Logs = logs,
+            Requests = requests,
+            Responses = responses
+        };
+}
+
 public record DiagnosticModel
 {
     public required DiagnosticName Name { get; init; }
     public required LoggerName LoggerName { get; init; }
     public Option<string> AlwaysLog { get; init; }
     public Option<DiagnosticSampling> Sampling { get; init; }
+    public Option<DiagnosticLargeLanguageModel> LargeLanguageModel { get; init; }
 
     public static Gen<DiagnosticModel> Generate() =>
         from name in GenerateName()
@@ -33,12 +67,14 @@ public record DiagnosticModel
         from loggerName in LoggerModel.GenerateName(loggerType)
         from alwaysLog in Gen.Const("allErrors").OptionOf()
         from sampling in DiagnosticSampling.Generate().OptionOf()
+        from largeLanguageModel in DiagnosticLargeLanguageModel.Generate().OptionOf()
         select new DiagnosticModel
         {
             Name = name,
             LoggerName = loggerName,
             AlwaysLog = alwaysLog,
-            Sampling = sampling
+            Sampling = sampling,
+            LargeLanguageModel = largeLanguageModel
         };
 
     public static Gen<DiagnosticName> GenerateName() =>

--- a/tools/code/common.tests/Diagnostic.cs
+++ b/tools/code/common.tests/Diagnostic.cs
@@ -82,5 +82,20 @@ public record DiagnosticModel
         select DiagnosticName.From(name);
 
     public static Gen<FrozenSet<DiagnosticModel>> GenerateSet() =>
-        Generate().FrozenSetOf(x => x.Name, 0, 20);
+        from diagnostics in Generate().FrozenSetOf(x => x.Name, 0, 20)
+        from largeLanguageModel in DiagnosticLargeLanguageModel.Generate()
+        select EnsureLargeLanguageModel(diagnostics, largeLanguageModel);
+
+    private static FrozenSet<DiagnosticModel> EnsureLargeLanguageModel(FrozenSet<DiagnosticModel> diagnostics, DiagnosticLargeLanguageModel largeLanguageModel)
+    {
+        if (diagnostics.Count == 0 || diagnostics.Any(diagnostic => diagnostic.LargeLanguageModel.IsSome))
+        {
+            return diagnostics;
+        }
+
+        var diagnosticArray = diagnostics.ToArray();
+        diagnosticArray[0] = diagnosticArray[0] with { LargeLanguageModel = LanguageExt.Prelude.Some(largeLanguageModel) };
+
+        return diagnosticArray.ToFrozenSet(x => x.Name);
+    }
 }

--- a/tools/code/common.tests/common.tests.csproj
+++ b/tools/code/common.tests/common.tests.csproj
@@ -7,12 +7,19 @@
 		<AnalysisLevel>8-all</AnalysisLevel>
 		<WarningsNotAsErrors>CA1034,CA1062,CA1724,CA2007,CA1848,CA1716,NU1903</WarningsNotAsErrors>
 		<Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.0" />
 		<PackageReference Include="CsCheck" Version="3.2.2" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tools/code/common/ApiDiagnostic.cs
+++ b/tools/code/common/ApiDiagnostic.cs
@@ -292,7 +292,7 @@ public static class ApiDiagnosticModule
     public static async ValueTask<ApiDiagnosticDto> GetDto(this ApiDiagnosticUri uri, HttpPipeline pipeline, CancellationToken cancellationToken)
     {
         var content = await pipeline.GetContent(uri.ToUri(), cancellationToken);
-        return content.ToObjectFromJson<ApiDiagnosticDto>();
+        return content.ToObjectFromJson<ApiDiagnosticDto>(JsonObjectExtensions.SerializerOptions);
     }
 
     public static async ValueTask Delete(this ApiDiagnosticUri uri, HttpPipeline pipeline, CancellationToken cancellationToken) =>
@@ -300,7 +300,7 @@ public static class ApiDiagnosticModule
 
     public static async ValueTask PutDto(this ApiDiagnosticUri uri, ApiDiagnosticDto dto, HttpPipeline pipeline, CancellationToken cancellationToken)
     {
-        var content = BinaryData.FromObjectAsJson(dto);
+        var content = BinaryData.FromObjectAsJson(dto, JsonObjectExtensions.SerializerOptions);
         await pipeline.PutContent(uri.ToUri(), content, cancellationToken);
     }
 
@@ -331,6 +331,6 @@ public static class ApiDiagnosticModule
     public static async ValueTask<ApiDiagnosticDto> ReadDto(this ApiDiagnosticInformationFile file, CancellationToken cancellationToken)
     {
         var content = await file.ToFileInfo().ReadAsBinaryData(cancellationToken);
-        return content.ToObjectFromJson<ApiDiagnosticDto>();
+        return content.ToObjectFromJson<ApiDiagnosticDto>(JsonObjectExtensions.SerializerOptions);
     }
 }

--- a/tools/code/common/ApiDiagnostic.cs
+++ b/tools/code/common/ApiDiagnostic.cs
@@ -147,6 +147,10 @@ public sealed record ApiDiagnosticDto
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string? HttpCorrelationProtocol { get; init; }
 
+        [JsonPropertyName("largeLanguageModel")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public LargeLanguageModelSettings? LargeLanguageModel { get; init; }
+
         [JsonPropertyName("logClientIp")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public bool? LogClientIp { get; init; }
@@ -232,6 +236,32 @@ public sealed record ApiDiagnosticDto
         [JsonPropertyName("samplingType")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string? SamplingType { get; init; }
+    }
+
+    public sealed record LargeLanguageModelSettings
+    {
+        [JsonPropertyName("logs")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string? Logs { get; init; }
+
+        [JsonPropertyName("requests")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public LargeLanguageModelMessageSettings? Requests { get; init; }
+
+        [JsonPropertyName("responses")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public LargeLanguageModelMessageSettings? Responses { get; init; }
+    }
+
+    public sealed record LargeLanguageModelMessageSettings
+    {
+        [JsonPropertyName("messages")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string? Messages { get; init; }
+
+        [JsonPropertyName("maxSizeInBytes")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public int? MaxSizeInBytes { get; init; }
     }
 }
 

--- a/tools/code/common/Diagnostic.cs
+++ b/tools/code/common/Diagnostic.cs
@@ -287,13 +287,13 @@ public static class DiagnosticModule
     public static async ValueTask<Option<DiagnosticDto>> TryGetDto(this DiagnosticUri uri, HttpPipeline pipeline, CancellationToken cancellationToken)
     {
         var contentOption = await pipeline.GetContentOption(uri.ToUri(), cancellationToken);
-        return contentOption.Map(content => content.ToObjectFromJson<DiagnosticDto>());
+        return contentOption.Map(content => content.ToObjectFromJson<DiagnosticDto>(JsonObjectExtensions.SerializerOptions));
     }
 
     public static async ValueTask<DiagnosticDto> GetDto(this DiagnosticUri uri, HttpPipeline pipeline, CancellationToken cancellationToken)
     {
         var content = await pipeline.GetContent(uri.ToUri(), cancellationToken);
-        return content.ToObjectFromJson<DiagnosticDto>();
+        return content.ToObjectFromJson<DiagnosticDto>(JsonObjectExtensions.SerializerOptions);
     }
 
     public static async ValueTask Delete(this DiagnosticUri uri, HttpPipeline pipeline, CancellationToken cancellationToken) =>
@@ -301,7 +301,7 @@ public static class DiagnosticModule
 
     public static async ValueTask PutDto(this DiagnosticUri uri, DiagnosticDto dto, HttpPipeline pipeline, CancellationToken cancellationToken)
     {
-        var content = BinaryData.FromObjectAsJson(dto);
+        var content = BinaryData.FromObjectAsJson(dto, JsonObjectExtensions.SerializerOptions);
         await pipeline.PutContent(uri.ToUri(), content, cancellationToken);
     }
 
@@ -329,7 +329,7 @@ public static class DiagnosticModule
     public static async ValueTask<DiagnosticDto> ReadDto(this DiagnosticInformationFile file, CancellationToken cancellationToken)
     {
         var content = await file.ToFileInfo().ReadAsBinaryData(cancellationToken);
-        return content.ToObjectFromJson<DiagnosticDto>();
+        return content.ToObjectFromJson<DiagnosticDto>(JsonObjectExtensions.SerializerOptions);
     }
 
     public static Option<LoggerName> TryGetLoggerName(DiagnosticDto dto) =>

--- a/tools/code/common/Diagnostic.cs
+++ b/tools/code/common/Diagnostic.cs
@@ -144,6 +144,10 @@ public sealed record DiagnosticDto
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string? HttpCorrelationProtocol { get; init; }
 
+        [JsonPropertyName("largeLanguageModel")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public LargeLanguageModelSettings? LargeLanguageModel { get; init; }
+
         [JsonPropertyName("logClientIp")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public bool? LogClientIp { get; init; }
@@ -229,6 +233,32 @@ public sealed record DiagnosticDto
         [JsonPropertyName("samplingType")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string? SamplingType { get; init; }
+    }
+
+    public sealed record LargeLanguageModelSettings
+    {
+        [JsonPropertyName("logs")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string? Logs { get; init; }
+
+        [JsonPropertyName("requests")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public LargeLanguageModelMessageSettings? Requests { get; init; }
+
+        [JsonPropertyName("responses")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public LargeLanguageModelMessageSettings? Responses { get; init; }
+    }
+
+    public sealed record LargeLanguageModelMessageSettings
+    {
+        [JsonPropertyName("messages")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string? Messages { get; init; }
+
+        [JsonPropertyName("maxSizeInBytes")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public int? MaxSizeInBytes { get; init; }
     }
 }
 

--- a/tools/code/common/WorkspaceDiagnostic.cs
+++ b/tools/code/common/WorkspaceDiagnostic.cs
@@ -139,6 +139,10 @@ public sealed record WorkspaceDiagnosticDto
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string? HttpCorrelationProtocol { get; init; }
 
+        [JsonPropertyName("largeLanguageModel")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public LargeLanguageModelSettings? LargeLanguageModel { get; init; }
+
         [JsonPropertyName("logClientIp")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public bool? LogClientIp { get; init; }
@@ -224,6 +228,32 @@ public sealed record WorkspaceDiagnosticDto
         [JsonPropertyName("samplingType")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string? SamplingType { get; init; }
+    }
+
+    public sealed record LargeLanguageModelSettings
+    {
+        [JsonPropertyName("logs")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string? Logs { get; init; }
+
+        [JsonPropertyName("requests")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public LargeLanguageModelMessageSettings? Requests { get; init; }
+
+        [JsonPropertyName("responses")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public LargeLanguageModelMessageSettings? Responses { get; init; }
+    }
+
+    public sealed record LargeLanguageModelMessageSettings
+    {
+        [JsonPropertyName("messages")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string? Messages { get; init; }
+
+        [JsonPropertyName("maxSizeInBytes")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public int? MaxSizeInBytes { get; init; }
     }
 }
 

--- a/tools/code/common/WorkspaceDiagnostic.cs
+++ b/tools/code/common/WorkspaceDiagnostic.cs
@@ -276,7 +276,7 @@ public static class WorkspaceDiagnosticModule
     public static async ValueTask<WorkspaceDiagnosticDto> GetDto(this WorkspaceDiagnosticUri uri, HttpPipeline pipeline, CancellationToken cancellationToken)
     {
         var content = await pipeline.GetContent(uri.ToUri(), cancellationToken);
-        return content.ToObjectFromJson<WorkspaceDiagnosticDto>();
+        return content.ToObjectFromJson<WorkspaceDiagnosticDto>(JsonObjectExtensions.SerializerOptions);
     }
 
     public static async ValueTask Delete(this WorkspaceDiagnosticUri uri, HttpPipeline pipeline, CancellationToken cancellationToken) =>
@@ -284,7 +284,7 @@ public static class WorkspaceDiagnosticModule
 
     public static async ValueTask PutDto(this WorkspaceDiagnosticUri uri, WorkspaceDiagnosticDto dto, HttpPipeline pipeline, CancellationToken cancellationToken)
     {
-        var content = BinaryData.FromObjectAsJson(dto);
+        var content = BinaryData.FromObjectAsJson(dto, JsonObjectExtensions.SerializerOptions);
         await pipeline.PutContent(uri.ToUri(), content, cancellationToken);
     }
 
@@ -297,6 +297,6 @@ public static class WorkspaceDiagnosticModule
     public static async ValueTask<WorkspaceDiagnosticDto> ReadDto(this WorkspaceDiagnosticInformationFile file, CancellationToken cancellationToken)
     {
         var content = await file.ToFileInfo().ReadAsBinaryData(cancellationToken);
-        return content.ToObjectFromJson<WorkspaceDiagnosticDto>();
+        return content.ToObjectFromJson<WorkspaceDiagnosticDto>(JsonObjectExtensions.SerializerOptions);
     }
 }

--- a/tools/code/integration.tests/ApiDiagnostic.cs
+++ b/tools/code/integration.tests/ApiDiagnostic.cs
@@ -60,25 +60,10 @@ internal static class ApiDiagnosticModule
         {
             var serviceUri = getServiceUri(serviceName);
             var diagnosticUri = ApiDiagnosticUri.From(model.Name, apiName, serviceUri);
-            var dto = getDto(model);
+            var dto = MapToDto(model);
 
             await diagnosticUri.PutDto(dto, pipeline, cancellationToken);
         }
-
-        static ApiDiagnosticDto getDto(ApiDiagnosticModel model) =>
-            new()
-            {
-                Properties = new ApiDiagnosticDto.DiagnosticContract
-                {
-                    LoggerId = $"/loggers/{model.LoggerName}",
-                    AlwaysLog = model.AlwaysLog.ValueUnsafe(),
-                    Sampling = model.Sampling.Map(sampling => new ApiDiagnosticDto.SamplingSettings
-                    {
-                        SamplingType = sampling.Type,
-                        Percentage = sampling.Percentage
-                    }).ValueUnsafe()
-                }
-            };
     }
 
     public static void ConfigureValidateExtractedApiDiagnostics(IHostApplicationBuilder builder)
@@ -119,6 +104,7 @@ internal static class ApiDiagnosticModule
             {
                 LoggerId = string.Join('/', dto.Properties.LoggerId?.Split('/')?.TakeLast(2)?.ToArray() ?? []),
                 AlwaysLog = dto.Properties.AlwaysLog ?? string.Empty,
+                LargeLanguageModel = NormalizeLargeLanguageModel(dto.Properties.LargeLanguageModel),
                 Sampling = new
                 {
                     Type = dto.Properties.Sampling?.SamplingType ?? string.Empty,
@@ -240,25 +226,10 @@ internal static class ApiDiagnosticModule
         async ValueTask writeInformationFile(ApiDiagnosticModel model, ApiName apiName, ManagementServiceDirectory serviceDirectory, CancellationToken cancellationToken)
         {
             var informationFile = ApiDiagnosticInformationFile.From(model.Name, apiName, serviceDirectory);
-            var dto = getDto(model);
+            var dto = MapToDto(model);
 
             await informationFile.WriteDto(dto, cancellationToken);
         }
-
-        static ApiDiagnosticDto getDto(ApiDiagnosticModel model) =>
-            new()
-            {
-                Properties = new ApiDiagnosticDto.DiagnosticContract
-                {
-                    LoggerId = $"/loggers/{model.LoggerName}",
-                    AlwaysLog = model.AlwaysLog.ValueUnsafe(),
-                    Sampling = model.Sampling.Map(sampling => new ApiDiagnosticDto.SamplingSettings
-                    {
-                        SamplingType = sampling.Type,
-                        Percentage = sampling.Percentage
-                    }).ValueUnsafe()
-                }
-            };
     }
     public static void ConfigureValidatePublishedApiDiagnostics(IHostApplicationBuilder builder)
     {
@@ -298,6 +269,7 @@ internal static class ApiDiagnosticModule
             {
                 LoggerId = string.Join('/', dto.Properties.LoggerId?.Split('/')?.TakeLast(2)?.ToArray() ?? []),
                 AlwaysLog = dto.Properties.AlwaysLog ?? string.Empty,
+                LargeLanguageModel = NormalizeLargeLanguageModel(dto.Properties.LargeLanguageModel),
                 Sampling = new
                 {
                     Type = dto.Properties.Sampling?.SamplingType ?? string.Empty,
@@ -305,6 +277,52 @@ internal static class ApiDiagnosticModule
                 }
             }.ToString()!;
     }
+
+    private static ApiDiagnosticDto MapToDto(ApiDiagnosticModel model) =>
+        new()
+        {
+            Properties = new ApiDiagnosticDto.DiagnosticContract
+            {
+                LoggerId = $"/loggers/{model.LoggerName}",
+                AlwaysLog = model.AlwaysLog.ValueUnsafe(),
+                Sampling = model.Sampling.Map(sampling => new ApiDiagnosticDto.SamplingSettings
+                {
+                    SamplingType = sampling.Type,
+                    Percentage = sampling.Percentage
+                }).ValueUnsafe(),
+                LargeLanguageModel = model.LargeLanguageModel.Match<ApiDiagnosticDto.LargeLanguageModelSettings?>(MapLargeLanguageModel, () => null)
+            }
+        };
+
+    private static ApiDiagnosticDto.LargeLanguageModelSettings MapLargeLanguageModel(ApiDiagnosticLargeLanguageModel largeLanguageModel) =>
+        new()
+        {
+            Logs = largeLanguageModel.Logs.Match(logs => logs, () => (string?)null),
+            Requests = largeLanguageModel.Requests.Match<ApiDiagnosticDto.LargeLanguageModelMessageSettings?>(MapLargeLanguageModelMessages, () => null),
+            Responses = largeLanguageModel.Responses.Match<ApiDiagnosticDto.LargeLanguageModelMessageSettings?>(MapLargeLanguageModelMessages, () => null)
+        };
+
+    private static ApiDiagnosticDto.LargeLanguageModelMessageSettings MapLargeLanguageModelMessages(ApiDiagnosticLargeLanguageModelMessages messages) =>
+        new()
+        {
+            Messages = messages.Messages,
+            MaxSizeInBytes = messages.MaxSizeInBytes
+        };
+
+    private static object NormalizeLargeLanguageModel(ApiDiagnosticDto.LargeLanguageModelSettings? largeLanguageModel) =>
+        new
+        {
+            Logs = largeLanguageModel?.Logs ?? string.Empty,
+            Requests = NormalizeLargeLanguageModelMessages(largeLanguageModel?.Requests),
+            Responses = NormalizeLargeLanguageModelMessages(largeLanguageModel?.Responses)
+        };
+
+    private static object NormalizeLargeLanguageModelMessages(ApiDiagnosticDto.LargeLanguageModelMessageSettings? largeLanguageModelMessages) =>
+        new
+        {
+            Messages = largeLanguageModelMessages?.Messages ?? string.Empty,
+            MaxSizeInBytes = largeLanguageModelMessages?.MaxSizeInBytes ?? 0
+        };
 }
 //internal static class ApiDiagnosticModule
 //{

--- a/tools/code/integration.tests/ApiDiagnostic.cs
+++ b/tools/code/integration.tests/ApiDiagnostic.cs
@@ -181,7 +181,7 @@ internal static class ApiDiagnosticModule
                 using (contents)
                 {
                     var data = await BinaryData.FromStreamAsync(contents, cancellationToken);
-                    var dto = data.ToObjectFromJson<ApiDiagnosticDto>();
+                    var dto = data.ToObjectFromJson<ApiDiagnosticDto>(JsonObjectExtensions.SerializerOptions);
                     return (name, dto);
                 }
             });

--- a/tools/code/integration.tests/Diagnostic.cs
+++ b/tools/code/integration.tests/Diagnostic.cs
@@ -89,26 +89,11 @@ public static class DiagnosticModule
         {
             var serviceUri = getServiceUri(serviceName);
 
-            var dto = getDto(model);
+            var dto = MapToDto(model);
 
             await DiagnosticUri.From(model.Name, serviceUri)
                             .PutDto(dto, pipeline, cancellationToken);
         }
-
-        static DiagnosticDto getDto(DiagnosticModel model) =>
-            new()
-            {
-                Properties = new DiagnosticDto.DiagnosticContract
-                {
-                    LoggerId = $"/loggers/{model.LoggerName}",
-                    AlwaysLog = model.AlwaysLog.ValueUnsafe(),
-                    Sampling = model.Sampling.Map(sampling => new DiagnosticDto.SamplingSettings
-                    {
-                        SamplingType = sampling.Type,
-                        Percentage = sampling.Percentage
-                    }).ValueUnsafe()
-                }
-            };
     }
 
     public static void ConfigureValidateExtractedDiagnostics(IHostApplicationBuilder builder)
@@ -154,6 +139,7 @@ public static class DiagnosticModule
             {
                 LoggerId = string.Join('/', dto.Properties.LoggerId?.Split('/')?.TakeLast(2)?.ToArray() ?? []),
                 AlwaysLog = dto.Properties.AlwaysLog ?? string.Empty,
+                LargeLanguageModel = NormalizeLargeLanguageModel(dto.Properties.LargeLanguageModel),
                 Sampling = new
                 {
                     Type = dto.Properties.Sampling?.SamplingType ?? string.Empty,
@@ -275,25 +261,10 @@ public static class DiagnosticModule
         static async ValueTask writeInformationFile(DiagnosticModel model, ManagementServiceDirectory serviceDirectory, CancellationToken cancellationToken)
         {
             var informationFile = DiagnosticInformationFile.From(model.Name, serviceDirectory);
-            var dto = getDto(model);
+            var dto = MapToDto(model);
 
             await informationFile.WriteDto(dto, cancellationToken);
         }
-
-        static DiagnosticDto getDto(DiagnosticModel model) =>
-            new()
-            {
-                Properties = new DiagnosticDto.DiagnosticContract
-                {
-                    LoggerId = $"/loggers/{model.LoggerName}",
-                    AlwaysLog = model.AlwaysLog.ValueUnsafe(),
-                    Sampling = model.Sampling.Map(sampling => new DiagnosticDto.SamplingSettings
-                    {
-                        SamplingType = sampling.Type,
-                        Percentage = sampling.Percentage
-                    }).ValueUnsafe()
-                }
-            };
     }
 
     public static void ConfigureValidatePublishedDiagnostics(IHostApplicationBuilder builder)
@@ -335,6 +306,7 @@ public static class DiagnosticModule
             {
                 LoggerId = string.Join('/', dto.Properties.LoggerId?.Split('/')?.TakeLast(2)?.ToArray() ?? []),
                 AlwaysLog = dto.Properties.AlwaysLog ?? string.Empty,
+                LargeLanguageModel = NormalizeLargeLanguageModel(dto.Properties.LargeLanguageModel),
                 Sampling = new
                 {
                     Type = dto.Properties.Sampling?.SamplingType ?? string.Empty,
@@ -346,15 +318,18 @@ public static class DiagnosticModule
     public static Gen<DiagnosticModel> GenerateUpdate(DiagnosticModel original) =>
         from alwaysLog in Gen.Const("allErrors").OptionOf()
         from sampling in DiagnosticSampling.Generate().OptionOf()
+        from largeLanguageModel in DiagnosticLargeLanguageModel.Generate().OptionOf()
         select original with
         {
             AlwaysLog = alwaysLog,
-            Sampling = sampling
+            Sampling = sampling,
+            LargeLanguageModel = largeLanguageModel
         };
 
     public static Gen<DiagnosticDto> GenerateOverride(DiagnosticDto original) =>
         from alwaysLog in Gen.Const("allErrors").OptionOf()
         from sampling in DiagnosticSampling.Generate().OptionOf()
+        from largeLanguageModel in DiagnosticLargeLanguageModel.Generate().OptionOf()
         select new DiagnosticDto
         {
             Properties = new DiagnosticDto.DiagnosticContract
@@ -364,14 +339,17 @@ public static class DiagnosticModule
                 {
                     SamplingType = sampling.Type,
                     Percentage = sampling.Percentage
-                }).ValueUnsafe()
+                }).ValueUnsafe(),
+                LargeLanguageModel = largeLanguageModel.Match(MapLargeLanguageModel, () => original.Properties.LargeLanguageModel)
             }
         };
 
     public static FrozenDictionary<DiagnosticName, DiagnosticDto> GetDtoDictionary(IEnumerable<DiagnosticModel> models) =>
         models.ToFrozenDictionary(model => model.Name, GetDto);
 
-    private static DiagnosticDto GetDto(DiagnosticModel model) =>
+    private static DiagnosticDto GetDto(DiagnosticModel model) => MapToDto(model);
+
+    private static DiagnosticDto MapToDto(DiagnosticModel model) =>
         new()
         {
             Properties = new DiagnosticDto.DiagnosticContract
@@ -382,7 +360,38 @@ public static class DiagnosticModule
                 {
                     SamplingType = sampling.Type,
                     Percentage = sampling.Percentage
-                }).ValueUnsafe()
+                }).ValueUnsafe(),
+                LargeLanguageModel = model.LargeLanguageModel.Match<DiagnosticDto.LargeLanguageModelSettings?>(MapLargeLanguageModel, () => null)
             }
+        };
+
+    private static DiagnosticDto.LargeLanguageModelSettings MapLargeLanguageModel(DiagnosticLargeLanguageModel largeLanguageModel) =>
+        new()
+        {
+            Logs = largeLanguageModel.Logs.Match(logs => logs, () => (string?)null),
+            Requests = largeLanguageModel.Requests.Match<DiagnosticDto.LargeLanguageModelMessageSettings?>(MapLargeLanguageModelMessages, () => null),
+            Responses = largeLanguageModel.Responses.Match<DiagnosticDto.LargeLanguageModelMessageSettings?>(MapLargeLanguageModelMessages, () => null)
+        };
+
+    private static DiagnosticDto.LargeLanguageModelMessageSettings MapLargeLanguageModelMessages(DiagnosticLargeLanguageModelMessages messages) =>
+        new()
+        {
+            Messages = messages.Messages,
+            MaxSizeInBytes = messages.MaxSizeInBytes
+        };
+
+    private static object NormalizeLargeLanguageModel(DiagnosticDto.LargeLanguageModelSettings? largeLanguageModel) =>
+        new
+        {
+            Logs = largeLanguageModel?.Logs ?? string.Empty,
+            Requests = NormalizeLargeLanguageModelMessages(largeLanguageModel?.Requests),
+            Responses = NormalizeLargeLanguageModelMessages(largeLanguageModel?.Responses)
+        };
+
+    private static object NormalizeLargeLanguageModelMessages(DiagnosticDto.LargeLanguageModelMessageSettings? largeLanguageModelMessages) =>
+        new
+        {
+            Messages = largeLanguageModelMessages?.Messages ?? string.Empty,
+            MaxSizeInBytes = largeLanguageModelMessages?.MaxSizeInBytes ?? 0
         };
 }

--- a/tools/code/integration.tests/Diagnostic.cs
+++ b/tools/code/integration.tests/Diagnostic.cs
@@ -218,7 +218,7 @@ public static class DiagnosticModule
                 using (contents)
                 {
                     var data = await BinaryData.FromStreamAsync(contents, cancellationToken);
-                    var dto = data.ToObjectFromJson<DiagnosticDto>();
+                    var dto = data.ToObjectFromJson<DiagnosticDto>(JsonObjectExtensions.SerializerOptions);
                     return (name, dto);
                 }
             });

--- a/tools/code/publisher/ApiDiagnostic.cs
+++ b/tools/code/publisher/ApiDiagnostic.cs
@@ -144,7 +144,7 @@ internal static class ApiDiagnosticModule
             var contentsOption = await tryGetFileContents(informationFile.ToFileInfo(), cancellationToken);
 
             return from contents in contentsOption
-                   let dto = contents.ToObjectFromJson<ApiDiagnosticDto>()
+                   let dto = contents.ToObjectFromJson<ApiDiagnosticDto>(JsonObjectExtensions.SerializerOptions)
                    select overrideDto(dto, name, apiName);
         };
 

--- a/tools/code/publisher/Diagnostic.cs
+++ b/tools/code/publisher/Diagnostic.cs
@@ -147,7 +147,7 @@ internal static class DiagnosticModule
             var contentsOption = await tryGetFileContents(informationFileInfo, cancellationToken);
 
             return from contents in contentsOption
-                   let dto = contents.ToObjectFromJson<DiagnosticDto>()
+                   let dto = contents.ToObjectFromJson<DiagnosticDto>(JsonObjectExtensions.SerializerOptions)
                    select overrideDto(name, dto);
         };
     }

--- a/tools/code/publisher/WorkspaceDiagnostic.cs
+++ b/tools/code/publisher/WorkspaceDiagnostic.cs
@@ -142,7 +142,7 @@ internal static class WorkspaceDiagnosticModule
             var contentsOption = await tryGetFileContents(informationFile.ToFileInfo(), cancellationToken);
 
             return from contents in contentsOption
-                   select contents.ToObjectFromJson<WorkspaceDiagnosticDto>();
+                   select contents.ToObjectFromJson<WorkspaceDiagnosticDto>(JsonObjectExtensions.SerializerOptions);
         };
     }
 


### PR DESCRIPTION
Resolves #785 

---

This pull request adds support for configuring and testing Large Language Model (LLM) diagnostics in the API and workspace diagnostic systems. The changes introduce new model and contract types to represent LLM settings, update test data generation, and refactor integration test helpers to handle these new structures.

## Details

### Large Language Model diagnostics support

* Added new contract types (`LargeLanguageModelSettings` and `LargeLanguageModelMessageSettings`) to `ApiDiagnostic.cs`, `Diagnostic.cs`, and `WorkspaceDiagnostic.cs` for serializing LLM diagnostic options, including logs, requests, and responses. 
* Extended the main diagnostic models (`ApiDiagnosticModel`, `DiagnosticModel`) and their test generators to include an optional `LargeLanguageModel` property and generation logic for LLM settings. 

### Integration test refactoring

* Refactored integration test helpers in `ApiDiagnostic.cs` and `Diagnostic.cs` to use a new `MapToDto` function, which maps the extended model to DTOs including LLM settings, replacing the previous `getDto` implementation. 
* Updated normalization logic in integration tests to handle LLM settings, ensuring consistent test output and comparison for diagnostics with LLM configuration. 

### Test data generation

* Updated generators for diagnostic model updates and DTO overrides to include LLM settings, enabling richer test coverage for diagnostics involving LLMs.

## Results

Here is the screenshot of extracted properties from my APIM resource.
<img width="727" height="677" alt="image" src="https://github.com/user-attachments/assets/b679964e-f031-4ffd-a7b5-c33fa2860986" />
