### PR TITLE
fix: treat HTTP 404 on DELETE as success (idempotent delete)

### DIFF
--- a/tools/code/common/Http.cs
+++ b/tools/code/common/Http.cs
@@ -128,7 +128,16 @@ public static class HttpPipelineExtensions
     {
         var either = await pipeline.TryDeleteResource(uri, waitForCompletion, cancellationToken);
 
-        either.IfLeftThrow(uri);
+        either.IfLeft(response =>
+        {
+            using (response)
+            {
+                if (response.Status != 404)
+                {
+                    throw response.ToHttpRequestException(uri);
+                }
+            }
+        });
     }
 
     public static async ValueTask<Either<Response, Unit>> TryDeleteResource(this HttpPipeline pipeline, Uri uri, bool waitForCompletion, CancellationToken cancellationToken)


### PR DESCRIPTION
When the publisher tries to delete a resource that has already been removed from APIM (e.g. a manually deleted API revision), the DELETE call returns HTTP 404. Previously, DeleteResource threw an exception on any error response including 404, causing the entire publisher pipeline to crash.

This change makes DeleteResource ignore 404 responses on DELETE, treating them as successful — the resource is already gone, which is the desired end state. This follows the REST convention of idempotent deletes and is consistent with how GetContentOption already handles 404 for GET requests.

The fix applies to all resource types (ApiTag, Api, Backend, Logger, Diagnostic, etc.) since they all call DeleteResource.