### PR TITLE
Fix publisher deadlock when workspace child resources are published in commit mode (#838)

### DIFF
--- a/src/publisher/Publisher.cs
+++ b/src/publisher/Publisher.cs
@@ -98,6 +98,13 @@ internal static class PublisherModule
 
             async ValueTask processDelete()
             {
+                // Skip if not actually being deleted this run (e.g. WorkspaceResource has no artifact file).
+                // Cascading to successors here would deadlock with their processPut tasks.
+                if (resourceSet.Contains(resourceKey) is false)
+                {
+                    return;
+                }
+
                 // Process successors first
                 var successors = previousRelationships.Successors
                                                       .Find(resourceKey)
@@ -108,10 +115,7 @@ internal static class PublisherModule
                                                   cancellationToken);
 
                 // Delete resource
-                if (resourceSet.Contains(resourceKey))
-                {
-                    await deleteResource(resourceKey, cancellationToken);
-                }
+                await deleteResource(resourceKey, cancellationToken);
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes #838

When running the publisher in commit mode (`COMMIT_ID` set) with
`FeatureManagement__Workspaces=true`, the process would hang indefinitely
after printing "Running publisher..." with no APIM calls and no error output.

## Root Cause

`processDelete` cascaded to child successor tasks for every resource where
`isInFileSystem = false`, not only resources actually being deleted.
`WorkspaceResource` has no artifact file and is never part of the resource set,
so it always entered `processDelete`. Its cascade logic then awaited workspace
child tasks (e.g. `WorkspaceApiResource`), which were themselves waiting for
the workspace task via the predecessor relationship — a circular wait:

1. `WorkspaceApiResource` (Task-A) waits for its predecessor `WorkspaceResource` (Task-B).
2. Task-B enters `processDelete`, cascades to successors, waits for Task-A.
3. Task-A is waiting for Task-B → deadlock.

This affects all workspace child resource types and only triggers when `COMMIT_ID`
is set and the modified file belongs to a workspace artifact that already existed
in the previous commit.

## Fix

Add a guard at the top of `processDelete` that returns immediately when the
resource is not in the resource set. The existing conditional around
`deleteResource` is removed as it is unreachable in that case.

## Reproduction

1. Modify an existing workspace artifact (e.g. `workspaces/<ws>/apis/<api>/specification.yaml`) 
2. Commit and note the hash.
3. Run the publisher with `COMMIT_ID=<hash>` and `FeatureManagement__Workspaces=true`.
4. **Before fix:** publisher hangs indefinitely. **After fix:** completes successfully.