### PR TITLE
Add missing dependency between backends and policies

### DIFF
--- a/SampleArtifacts/apis/basic-api/policy.xml
+++ b/SampleArtifacts/apis/basic-api/policy.xml
@@ -1,6 +1,6 @@
 <policies>
 	<inbound>
-		<set-backend-service base-url="{{intranet-proxy-url}}" />
+		<set-backend-service backend-id="backend1" />
 		<set-header name="X-Api" exists-action="override">
 			<value>basic-api</value>
 		</set-header>

--- a/src/common/Resource.cs
+++ b/src/common/Resource.cs
@@ -308,6 +308,12 @@ public static class ResourceExtensions
             {
                 list.Add(PolicyFragmentResource.Instance);
             }
+
+            // Policies can reference backends
+            var isWorkspacePolicy = resource.GetTraversalPredecessorHierarchy()
+                                            .Contains(WorkspaceResource.Instance);
+
+            list.Add(isWorkspacePolicy ? WorkspaceBackendResource.Instance : BackendResource.Instance);
         }
 
         return [.. list];

--- a/src/integration.tests/ApiOperationPolicy.cs
+++ b/src/integration.tests/ApiOperationPolicy.cs
@@ -73,8 +73,9 @@ internal sealed record ApiOperationPolicyModel : ITestModel<ApiOperationPolicyMo
     {
         var namedValues = models.OfType<NamedValueModel>();
         var fragments = models.OfType<PolicyFragmentModel>();
+        var backends = models.OfType<BackendModel>();
 
-        return from inboundSnippet in PolicyModule.GenerateInboundSnippet(namedValues, fragments)
+        return from inboundSnippet in PolicyModule.GenerateInboundSnippet(namedValues, fragments, backends)
                from outboundSnippet in PolicyModule.GenerateOutboundSnippet(namedValues, fragments)
                select $"""
                        <policies>

--- a/src/integration.tests/ApiPolicy.cs
+++ b/src/integration.tests/ApiPolicy.cs
@@ -57,8 +57,9 @@ internal sealed record ApiPolicyModel : ITestModel<ApiPolicyModel>
     {
         var namedValues = models.OfType<NamedValueModel>();
         var fragments = models.OfType<PolicyFragmentModel>();
+        var backends = models.OfType<BackendModel>();
 
-        return from inboundSnippet in PolicyModule.GenerateInboundSnippet(namedValues, fragments)
+        return from inboundSnippet in PolicyModule.GenerateInboundSnippet(namedValues, fragments, backends)
                from outboundSnippet in PolicyModule.GenerateOutboundSnippet(namedValues, fragments)
                select $"""
                        <policies>

--- a/src/integration.tests/Common.cs
+++ b/src/integration.tests/Common.cs
@@ -95,18 +95,28 @@ internal static class PolicyModule
                          .Select(model => Gen.Const($$$"""{{{{{model.DisplayName}}}}}"""))
                          .Append(Generator.AlphanumericWord)]);
 
-    public static Gen<string> GenerateInboundSnippet(IEnumerable<NamedValueModel> namedValues, IEnumerable<PolicyFragmentModel> fragments) =>
+    public static Gen<string> GenerateInboundSnippet(IEnumerable<NamedValueModel> namedValues, IEnumerable<PolicyFragmentModel> fragments, IEnumerable<BackendModel> backends) =>
         from snippetGens in Generator.SubSetOf([GenerateSetVariableSnippet(namedValues),
                                                 GenerateIpFilterSnippet(),
                                                 GenerateFindAndReplaceSnippet(namedValues),
                                                 GenerateSetHeaderSnippet(namedValues),
-                                                GenerateIncludeFragmentSnippet(fragments)])
+                                                GenerateIncludeFragmentSnippet(fragments),
+                                                GenerateSetBackendServiceSnippet(backends)])
         from snippets in Generator.Traverse(snippetGens, gen => gen)
         select $"""
                 <inbound>
                     {string.Join(Environment.NewLine, snippets)}
                 </inbound>
                 """;
+
+    private static Gen<string> GenerateSetBackendServiceSnippet(IEnumerable<BackendModel> backends) =>
+        backends.ToImmutableArray() switch
+        {
+            [] => from url in Generator.AbsoluteUri
+                  select $"""<set-backend-service base-url="{url}" />""",
+            var nonEmptyBackends => from backend in Gen.OneOfConst([.. nonEmptyBackends])
+                                    select $"""<set-backend-service backend-id="{backend.Key.Name}" />"""
+        };
 
     private static Gen<string> GenerateIpFilterSnippet() =>
         from last3 in Gen.Int[0, 255].Array[3]

--- a/src/integration.tests/ProductPolicy.cs
+++ b/src/integration.tests/ProductPolicy.cs
@@ -47,8 +47,9 @@ internal sealed record ProductPolicyModel : ITestModel<ProductPolicyModel>
     {
         var namedValues = models.OfType<NamedValueModel>();
         var fragments = models.OfType<PolicyFragmentModel>();
+        var backends = models.OfType<BackendModel>();
 
-        return from inboundSnippet in PolicyModule.GenerateInboundSnippet(namedValues, fragments)
+        return from inboundSnippet in PolicyModule.GenerateInboundSnippet(namedValues, fragments, backends)
                from outboundSnippet in PolicyModule.GenerateOutboundSnippet(namedValues, fragments)
                select $"""
                        <policies>

--- a/src/integration.tests/ServicePolicy.cs
+++ b/src/integration.tests/ServicePolicy.cs
@@ -59,8 +59,9 @@ internal sealed record ServicePolicyModel : ITestModel<ServicePolicyModel>
     {
         var namedValues = models.OfType<NamedValueModel>();
         var fragments = models.OfType<PolicyFragmentModel>();
+        var backends = models.OfType<BackendModel>();
 
-        return from inboundSnippet in PolicyModule.GenerateInboundSnippet(namedValues, fragments)
+        return from inboundSnippet in PolicyModule.GenerateInboundSnippet(namedValues, fragments, backends)
                from outboundSnippet in PolicyModule.GenerateOutboundSnippet(namedValues, fragments)
                select $"""
                        <policies>

--- a/src/publisher.tests/Relationships.cs
+++ b/src/publisher.tests/Relationships.cs
@@ -957,6 +957,98 @@ internal sealed class GetRelationshipPairsTests
     }
 
     [Test]
+    public async Task Returns_policy_to_backend_relationships()
+    {
+        var gen = from fixture in Fixture.Generate()
+                  from backendKey in Generator.GenerateResourceKey(resource => resource is BackendResource)
+                  from policyKey in Generator.GenerateResourceKey(resource => resource is IPolicyResource
+                                                                          and not PolicyFragmentResource
+                                                                          and not WorkspacePolicyFragmentResource)
+                  let policyContent = $"<policies><inbound><set-backend-service backend-id=\"{backendKey.Name}\" /><base /></inbound></policies>"
+                  let resources = RelationshipTestData.ToResourceMap([policyKey, backendKey])
+                  select (backendKey, policyKey, policyContent, resources, Common.NoOpFileOperations, fixture with
+                  {
+                      GetPolicyFileContents = async (resource, name, parents, readFile, cancellationToken) =>
+                      {
+                          await ValueTask.CompletedTask;
+
+                          var key = ResourceKey.From(resource, name, parents);
+
+                          return key == policyKey
+                                    ? BinaryData.FromString(policyContent)
+                                    : Option.None;
+                      }
+                  });
+
+        await gen.SampleAsync(async tuple =>
+        {
+            // Arrange
+            var (backendKey, policyKey, policyContent, resources, fileOperations, fixture) = tuple;
+            var getRelationshipPairs = fixture.Resolve();
+
+            // Act
+            var pairs = await getRelationshipPairs(resources, fileOperations, CancellationToken);
+            var relationships = Relationships.From(pairs, CancellationToken);
+
+            // Assert that the backend is a predecessor of the policy
+            await Assert.That(relationships.Predecessors[policyKey])
+                        .Contains(backendKey);
+        });
+    }
+
+    [Test]
+    public async Task Returns_workspace_policy_to_workspace_backend_relationships()
+    {
+        var gen = from fixture in Fixture.Generate()
+                  from workspaceKey in Generator.GenerateResourceKey(resource => resource is WorkspaceResource)
+                  let setWorkspace = new Func<ResourceKey, ResourceKey>(key => key with
+                  {
+                      Parents = ParentChain.From([.. from pair in key.Parents
+                                                     select pair.Resource is WorkspaceResource
+                                                         ? (WorkspaceResource.Instance, workspaceKey.Name)
+                                                         : pair])
+                  })
+                  from backendKey in
+                      from backendKey in Generator.GenerateResourceKey(resource => resource is WorkspaceBackendResource)
+                      select setWorkspace(backendKey)
+                  from policyKey in
+                      from policyKey in Generator.GenerateResourceKey(resource => resource is IPolicyResource and not WorkspacePolicyFragmentResource
+                                                                                  && resource.GetTraversalPredecessorHierarchy()
+                                                                                             .Contains(WorkspaceResource.Instance))
+                      select setWorkspace(policyKey)
+                  let policyContent = $"<policies><inbound><set-backend-service backend-id=\"{backendKey.Name}\" /><base /></inbound></policies>"
+                  let resources = RelationshipTestData.ToResourceMap([policyKey, backendKey])
+                  select (backendKey, policyKey, policyContent, resources, Common.NoOpFileOperations, fixture with
+                  {
+                      GetPolicyFileContents = async (resource, name, parents, readFile, cancellationToken) =>
+                      {
+                          await ValueTask.CompletedTask;
+
+                          var key = ResourceKey.From(resource, name, parents);
+
+                          return key == policyKey
+                                    ? BinaryData.FromString(policyContent)
+                                    : Option.None;
+                      }
+                  });
+
+        await gen.SampleAsync(async tuple =>
+        {
+            // Arrange
+            var (backendKey, policyKey, policyContent, resources, fileOperations, fixture) = tuple;
+            var getRelationshipPairs = fixture.Resolve();
+
+            // Act
+            var pairs = await getRelationshipPairs(resources, fileOperations, CancellationToken);
+            var relationships = Relationships.From(pairs, CancellationToken);
+
+            // Assert that the workspace backend is a predecessor of the policy
+            await Assert.That(relationships.Predecessors[policyKey])
+                        .Contains(backendKey);
+        });
+    }
+
+    [Test]
     public async Task Returns_a_missing_parent_relationship_for_a_child_resource()
     {
         var gen = from childKey in Generator.GenerateResourceKey(resource => resource is IChildResource

--- a/src/publisher/Relationships.cs
+++ b/src/publisher/Relationships.cs
@@ -256,6 +256,7 @@ internal static class RelationshipsModule
 
         var namedValueTokenRegex = new Regex("{{\\s*(.*?)\\s*}}", RegexOptions.CultureInvariant);
         var includeFragmentRegex = new Regex("<include-fragment\\s+fragment-id=\"([^\"]+)\"\\s*/>", RegexOptions.CultureInvariant);
+        var policyBackendIdRegex = new Regex("<set-backend-service\\b[^>]*\\bbackend-id\\s*=\\s*[\"']([^\"']+)[\"'][^>]*/?>", RegexOptions.CultureInvariant);
 
         return async (resources, operations, cancellationToken) =>
         {
@@ -350,6 +351,12 @@ internal static class RelationshipsModule
                                {
                                    var policyFragments = await getPolicyFragments(policyResourceForFragments, key.Name, key.Parents, operations.ReadFile, resources, cancellationToken);
                                    policyFragments.Iter(fragment => pairs.Add((fragment, key)), cancellationToken);
+                               }
+
+                               if (key.Resource is IPolicyResource policyResourceForBackends)
+                               {
+                                   var policyBackends = await getPolicyBackends(policyResourceForBackends, key.Name, key.Parents, operations.ReadFile, resources, cancellationToken);
+                                   policyBackends.Iter(backend => pairs.Add((backend, key)), cancellationToken);
                                }
 
                                dtoJsonOption.Iter(dtoJson =>
@@ -462,6 +469,15 @@ internal static class RelationshipsModule
                 return getPolicyFragmentsFromContent(contents, parents, resources);
             }
 
+            async ValueTask<ImmutableHashSet<ResourceKey>> getPolicyBackends(IPolicyResource resource, ResourceName name, ParentChain parents, ReadFile readFile, IDictionary<IResource, ImmutableHashSet<ResourceKey>> resources, CancellationToken cancellationToken)
+            {
+                var contentsOption = await getEffectivePolicyContents(resource, name, parents, readFile, cancellationToken);
+
+                var contents = contentsOption.IfNoneNull() ?? string.Empty;
+
+                return getPolicyBackendsFromContent(contents, parents, resources);
+            }
+
             ImmutableHashSet<ResourceKey> getNamedValuesFromContent(string content, ParentChain parents)
             {
                 if (string.IsNullOrWhiteSpace(content))
@@ -505,11 +521,37 @@ internal static class RelationshipsModule
             Option<ResourceKey> findPolicyFragment(ResourceName name, Option<(IResource, ResourceName)> workspaceOption, IDictionary<IResource, ImmutableHashSet<ResourceKey>> resources) =>
                 workspaceOption.Bind(workspace => from fragments in resources.Find(WorkspacePolicyFragmentResource.Instance)
                                                   from fragment in fragments.Head(key => key.Name == name
-                                                                                         && key.Parents.Any(parent => parent == workspace))
+                                                                                          && key.Parents.Any(parent => parent == workspace))
                                                   select fragment)
                                .IfNone(() => from fragments in resources.Find(PolicyFragmentResource.Instance)
                                              from fragment in fragments.Head(key => key.Name == name)
                                              select fragment);
+
+            ImmutableHashSet<ResourceKey> getPolicyBackendsFromContent(string content, ParentChain parents, IDictionary<IResource, ImmutableHashSet<ResourceKey>> resources)
+            {
+                if (string.IsNullOrWhiteSpace(content))
+                {
+                    return [];
+                }
+
+                var workspaceOption = parents.Head(tuple => tuple.Resource is WorkspaceResource);
+
+                var referencedBackends = policyBackendIdRegex.Matches(content)
+                                                             .Select(match => match.Groups[1].Value.Trim())
+                                                             .Choose(nameString => ResourceName.From(nameString).ToOption())
+                                                             .Choose(name => findBackend(name, workspaceOption, resources));
+
+                return [.. referencedBackends];
+            }
+
+            Option<ResourceKey> findBackend(ResourceName name, Option<(IResource, ResourceName)> workspaceOption, IDictionary<IResource, ImmutableHashSet<ResourceKey>> resources) =>
+                workspaceOption.Bind(workspace => from backends in resources.Find(WorkspaceBackendResource.Instance)
+                                                  from backend in backends.Head(key => key.Name == name
+                                                                                       && key.Parents.Any(parent => parent == workspace))
+                                                  select backend)
+                               .IfNone(() => from backends in resources.Find(BackendResource.Instance)
+                                             from backend in backends.Head(key => key.Name == name)
+                                             select backend);
 
             ResourceKey getParent(IChildResource resource, ResourceName name, ParentChain parents) =>
                 parents.LastOrDefault() switch


### PR DESCRIPTION
The publisher previously ignored potential relationships between backends and policies. This could lead to a policy `PUT` request happening before its referenced backend's, causing publisher errors.