### PR TITLE
Add and update SERVICE_CONNECTION_NAME parameter in pipeline

### DIFF
--- a/tools/azdo_pipelines/run-extractor.yaml
+++ b/tools/azdo_pipelines/run-extractor.yaml
@@ -29,6 +29,8 @@ parameters:
       - OpenAPIV3Json
       - OpenAPIV2Yaml
       - OpenAPIV2Json
+  - name: SERVICE_CONNECTION_NAME
+    type: string
 
 trigger: none
 
@@ -49,7 +51,7 @@ stages:
           - task: AzureCLI@2
             displayName: Set extraction variables
             inputs:
-              azureSubscription: "$(SERVICE_CONNECTION_NAME)"
+              azureSubscription: "${{ parameters.SERVICE_CONNECTION_NAME }}"
               scriptType: pscore
               scriptLocation: inlineScript
               inlineScript: |

--- a/tools/azdo_pipelines/run-publisher-with-env.yaml
+++ b/tools/azdo_pipelines/run-publisher-with-env.yaml
@@ -19,6 +19,8 @@ parameters:
   - name: COMMIT_ID
     type: string
     default: publish-artifacts-in-last-commit
+  - name: SERVICE_CONNECTION_NAME
+    type: string
 
 steps:
   - script: echo Provided configuration was ${{ parameters.CONFIGURATION_YAML_PATH }}
@@ -32,7 +34,7 @@ steps:
   - task: AzureCLI@2
     displayName: Set publishing variables
     inputs:
-      azureSubscription: "$(SERVICE_CONNECTION_NAME)"
+      azureSubscription: "${{ parameters.SERVICE_CONNECTION_NAME }}"
       scriptType: pscore
       scriptLocation: inlineScript
       inlineScript: |

--- a/tools/azdo_pipelines/run-publisher.yaml
+++ b/tools/azdo_pipelines/run-publisher.yaml
@@ -40,6 +40,7 @@ stages:
               API_MANAGEMENT_SERVICE_NAME : $(APIM_NAME)
               ENVIRONMENT: "Dev"
               COMMIT_ID: ${{ parameters.COMMIT_ID }}
+              SERVICE_CONNECTION_NAME: $(SERVICE_CONNECTION_NAME)
   - stage: push_changes_to_Prod_APIM
     displayName: Push changes to Prod APIM
     jobs:
@@ -64,4 +65,5 @@ stages:
                      CONFIGURATION_YAML_PATH:  $(Build.SourcesDirectory)/configuration.prod.yaml
                      ENVIRONMENT: "Prod"
                      COMMIT_ID: ${{ parameters.COMMIT_ID }}
+                     SERVICE_CONNECTION_NAME: $(SERVICE_CONNECTION_NAME)
               


### PR DESCRIPTION
This pull request updates the Azure DevOps pipeline YAML files to improve how the `SERVICE_CONNECTION_NAME` parameter is handled. The changes ensure that the service connection name is passed as a pipeline parameter and referenced consistently, making the pipelines more flexible and configurable.

**Pipeline parameterization and usage improvements:**

* Added a `SERVICE_CONNECTION_NAME` parameter to both `run-extractor.yaml` and `run-publisher-with-env.yaml` to allow the service connection name to be specified dynamically. [[1]](diffhunk://#diff-24463c395b020deb62b823e735e58bedd213025bb6cd946ed0a56e0827746dd8R32-R33) [[2]](diffhunk://#diff-ec9b44b529440738705805abebb6c0a84980902577cb58b8617030759e989a21R22-R23)
* Updated the usage of `azureSubscription` in `AzureCLI@2` tasks to reference the new parameterized `SERVICE_CONNECTION_NAME` instead of a hardcoded variable, ensuring correct parameter expansion. [[1]](diffhunk://#diff-24463c395b020deb62b823e735e58bedd213025bb6cd946ed0a56e0827746dd8L52-R54) [[2]](diffhunk://#diff-ec9b44b529440738705805abebb6c0a84980902577cb58b8617030759e989a21L35-R37)

**Pipeline variable propagation:**

* Modified `run-publisher.yaml` to pass the `SERVICE_CONNECTION_NAME` variable to downstream stages and jobs, ensuring consistent availability throughout the pipeline. [[1]](diffhunk://#diff-5b0cf51d69a000eea431e1ca850b16fa929ac47595cf5834877eacb0b11c2ffeR43) [[2]](diffhunk://#diff-5b0cf51d69a000eea431e1ca850b16fa929ac47595cf5834877eacb0b11c2ffeR68)

The main problem that I want to solve with this PR is that the variable is not picked up when it is defined at job or stage level. However, this is necessary if you have different service connections for different deployments or environments:
<img width="1331" height="54" alt="image" src="https://github.com/user-attachments/assets/74f0e36e-0000-4013-b1d2-8d9724c1d012" />
