### PR TITLE
Use absolute IDs for workspace tag links (#849)

### DIFF
--- a/src/common/Resource.FileSystem.cs
+++ b/src/common/Resource.FileSystem.cs
@@ -222,6 +222,10 @@ public static partial class ResourceModule
             (WorkspaceProductResource, WorkspaceGroupResource) => dto,
             // Workspace product APIs don't support relative IDs
             (WorkspaceProductResource, WorkspaceApiResource) => dto,
+            // Workspace tag APIs don't support relative IDs
+            (WorkspaceTagResource, WorkspaceApiResource) => dto,
+            // Workspace tag products don't support relative IDs
+            (WorkspaceTagResource, WorkspaceProductResource) => dto,
             _ => SetAbsoluteToRelativeId(dto, resource.DtoPropertyNameForLinkedResource)
         };
 


### PR DESCRIPTION
v7 introduced relative IDs during extraction. This doesn't work on workspace tag links. An extract -> publish cycle fails, as the publisher can't publish the relative IDs.

Closes #849 .