### PR TITLE
Don't extract composite resources when the secondary resource is skipped

### DIFF
--- a/src/extractor.tests/Extractor.cs
+++ b/src/extractor.tests/Extractor.cs
@@ -423,6 +423,61 @@ internal sealed class ShouldExtractTests
         });
     }
 
+    [Test]
+    public async Task Composite_resources_with_skipped_secondaries_are_skipped()
+    {
+        var gen = from resourceKey in Generator.GenerateResourceKey(resource => resource is ICompositeResource)
+                  let resource = resourceKey.Resource
+                  let secondaryResource = ((ICompositeResource)resource).Secondary
+                  from secondaryResourceKey in
+                      from secondaryResourceKey in Generator.GenerateResourceKey(resource => resource == secondaryResource)
+                      select secondaryResourceKey with
+                      {
+                          Name = resource is ILinkResource
+                                    ? secondaryResourceKey.Name
+                                    : resourceKey.Name,
+                          Parents = ParentChain.From(resourceKey.Parents
+                                                                .Take(secondaryResource.GetTraversalPredecessorHierarchy().Length))
+                      }
+                  let dto = resource switch
+                  {
+                      ILinkResource linkResource => new JsonObject
+                      {
+                          ["properties"] = new JsonObject
+                          {
+                              [linkResource.DtoPropertyNameForLinkedResource] = secondaryResourceKey.ToString()
+                          }
+                      },
+                      _ => []
+                  }
+                  let dtoOption = Option.Some(dto)
+                  from fixture in Fixture.Generate()
+                  let updatedFixture = fixture with
+                  {
+                      ResourceIsInConfiguration = async (key, cancellationToken) =>
+                      {
+                          await ValueTask.CompletedTask;
+
+                          // Always skip the secondary resource key
+                          return key != secondaryResourceKey;
+                      }
+                  }
+                  select (resourceKey, dtoOption, updatedFixture);
+
+        await gen.SampleAsync(async tuple =>
+        {
+            // Arrange
+            var (resourceKey, dtoOption, fixture) = tuple;
+            var shouldExtract = fixture.Resolve();
+
+            // Act
+            var extract = await shouldExtract(resourceKey, dtoOption, CancellationToken);
+
+            // Assert
+            await Assert.That(extract).IsFalse();
+        });
+    }
+
     private sealed record Fixture
     {
         public required ResourceIsInConfiguration ResourceIsInConfiguration { get; init; }

--- a/src/extractor/Extractor.cs
+++ b/src/extractor/Extractor.cs
@@ -186,7 +186,45 @@ internal static class ExtractorModule
                 }
             }
 
-            // Skip resources based on configuration
+            // Skip composite resources whose secondary is excluded in configuration.
+            if (resource is ICompositeResource compositeResource2)
+            {
+                bool skipResource = false;
+
+                var secondaryResourceKeyOption =
+                    from secondaryName in compositeResource2 switch
+                    {
+                        ILinkResource linkResource => from dto in dtoOption
+                                                      from secondaryResourceName in linkResource.GetSecondaryResourceName(dto)
+                                                      select secondaryResourceName,
+                        _ => Option.Some(name)
+                    }
+                    let secondaryPredecessorCount = compositeResource2.Secondary.GetTraversalPredecessorHierarchy().Length
+                    let secondaryParents = ParentChain.From(resourceKey.Parents.Take(secondaryPredecessorCount))
+                    let secondaryResourceKey = ResourceKey.From(compositeResource2.Secondary, secondaryName, secondaryParents)
+                    select secondaryResourceKey;
+
+                await secondaryResourceKeyOption.IterTask(async secondaryResourceKey =>
+                {
+                    var isInConfigurationOption = await resourceIsInConfiguration(secondaryResourceKey, cancellationToken);
+
+                    isInConfigurationOption.Iter(isInConfiguration =>
+                    {
+                        if (isInConfiguration is false)
+                        {
+                            skipResource = true;
+                            logger.LogWarning("Skipping composite resource '{ResourceKey}' because its secondary resource '{SecondaryResourceKey}' is not in configuration...", resourceKey, secondaryResourceKey);
+                        }
+                    });
+                });
+
+                if (skipResource)
+                {
+                    return false;
+                }
+            }
+
+            // Skip resources that are excluded in configuration.
             var isInConfigurationOption = await resourceIsInConfiguration(resourceKey, cancellationToken);
             var isInConfiguration = isInConfigurationOption.IfNone(() => true);
             if (isInConfiguration is false)


### PR DESCRIPTION
Fixes a regression in v7 (#856).