### PR TITLE
Preserve API overrides during spec publish by reusing publisher DTO

### DIFF
--- a/src/common/ApiSpecification.cs
+++ b/src/common/ApiSpecification.cs
@@ -519,7 +519,7 @@ public static partial class ResourceModule
     {
         var serviceDirectory = provider.GetRequiredService<ServiceDirectory>();
 
-        return async (resourceKey, baseDto, specification, contents, cancellationToken) =>
+        return async (resourceKey, specification, contents, cancellationToken) =>
         {
             var fileOption = GetSpecificationFile(resourceKey, specification, serviceDirectory);
 

--- a/src/common/ApiSpecification.cs
+++ b/src/common/ApiSpecification.cs
@@ -20,7 +20,7 @@ namespace common;
 public delegate ValueTask<Option<(ApiSpecification Specification, BinaryData Contents)>> GetApiSpecificationFromApim(ResourceKey resourceKey, JsonObject dto, CancellationToken cancellationToken);
 public delegate ValueTask<Option<(ApiSpecification Specification, BinaryData Contents)>> GetApiSpecificationFromFile(ResourceKey resourceKey, ReadFile readFile, CancellationToken cancellationToken);
 public delegate ValueTask WriteApiSpecificationFile(ResourceKey resourceKey, ApiSpecification specification, BinaryData contents, CancellationToken cancellationToken);
-public delegate ValueTask PutApiSpecificationInApim(ResourceKey resourceKey, ApiSpecification specification, BinaryData contents, CancellationToken cancellationToken);
+public delegate ValueTask PutApiSpecificationInApim(ResourceKey resourceKey, JsonObject baseDto, ApiSpecification specification, BinaryData contents, CancellationToken cancellationToken);
 
 public abstract record ApiSpecification
 {
@@ -519,7 +519,7 @@ public static partial class ResourceModule
     {
         var serviceDirectory = provider.GetRequiredService<ServiceDirectory>();
 
-        return async (resourceKey, specification, contents, cancellationToken) =>
+        return async (resourceKey, baseDto, specification, contents, cancellationToken) =>
         {
             var fileOption = GetSpecificationFile(resourceKey, specification, serviceDirectory);
 
@@ -547,7 +547,7 @@ public static partial class ResourceModule
         var resource = ApiResource.Instance;
         var ancestors = ParentChain.Empty;
 
-        return async (resourceKey, specification, contents, cancellationToken) =>
+        return async (resourceKey, baseDto, specification, contents, cancellationToken) =>
         {
             if (resourceKey.Resource is not ApiResource and not WorkspaceApiResource)
             {
@@ -556,7 +556,7 @@ public static partial class ResourceModule
 
             await (specification switch
             {
-                ApiSpecification.OpenApi openApiSpecification => putOpenApiSpecification(resourceKey, openApiSpecification, contents, cancellationToken),
+                ApiSpecification.OpenApi openApiSpecification => putOpenApiSpecification(resourceKey, baseDto, openApiSpecification, contents, cancellationToken),
                 ApiSpecification.Wadl wadlSpecification => putWadlSpecification(resourceKey, wadlSpecification, contents, cancellationToken),
                 ApiSpecification.Wsdl wsdlSpecification => putWsdlSpecification(resourceKey, wsdlSpecification, contents, cancellationToken),
                 ApiSpecification.GraphQl graphQlSpecification => putGraphQlSpecification(resourceKey, graphQlSpecification, contents, cancellationToken),
@@ -564,10 +564,9 @@ public static partial class ResourceModule
             });
         };
 
-        async ValueTask putOpenApiSpecification(ResourceKey resourceKey, ApiSpecification.OpenApi specification, BinaryData contents, CancellationToken cancellationToken)
+        async ValueTask putOpenApiSpecification(ResourceKey resourceKey, JsonObject baseDto, ApiSpecification.OpenApi specification, BinaryData contents, CancellationToken cancellationToken)
         {
-            var resource = (IResourceWithDto)resourceKey.Resource;
-            var dto = await getDto(resource, resourceKey.Name, resourceKey.Parents, cancellationToken);
+            var dto = baseDto.DeepClone().AsObject();
 
             dto = dto.MergeWith(new JsonObject
             {

--- a/src/integration.tests/Apim.cs
+++ b/src/integration.tests/Apim.cs
@@ -231,7 +231,7 @@ internal static class ApimModule
                              await specificationOption.IterTask(async tuple =>
                              {
                                  var (specification, contents) = tuple;
-                                 await putApiSpecification(model.Key, specification, contents, cancellationToken);
+                                 await putApiSpecification(model.Key, model.ToDto(), specification, contents, cancellationToken);
                              });
                          }, maxDegreeOfParallelism: Option.None, cancellationToken), cancellationToken),
                 IResourceWithDto resourceWithDto =>

--- a/src/publisher.tests/Api.cs
+++ b/src/publisher.tests/Api.cs
@@ -254,7 +254,7 @@ internal sealed class PutApiTests
                     await ValueTask.CompletedTask;
                     return specificationContents;
                 },
-                PutApiSpecificationInApim = async (_, _, _, _) =>
+                PutApiSpecificationInApim = async (_, _, _, _, _) =>
                 {
                     await ValueTask.CompletedTask;
                 }

--- a/src/publisher.tests/WorkspaceApi.cs
+++ b/src/publisher.tests/WorkspaceApi.cs
@@ -251,7 +251,7 @@ internal sealed class PutWorkspaceApiTests
                     await ValueTask.CompletedTask;
                     return specificationContents;
                 },
-                PutApiSpecificationInApim = async (_, _, _, _) =>
+                PutApiSpecificationInApim = async (_, _, _, _, _) =>
                 {
                     await ValueTask.CompletedTask;
                 }

--- a/src/publisher/Api.cs
+++ b/src/publisher/Api.cs
@@ -58,7 +58,7 @@ internal static partial class ResourceModule
 
             await putResourceInApim(resource, name, dto, parents, cancellationToken);
 
-            await putSpecification(name, cancellationToken);
+            await putSpecification(name, dto, cancellationToken);
         }
 
 
@@ -128,14 +128,14 @@ internal static partial class ResourceModule
             await deleteResourceFromApim(releaseResourceKey, ignoreNotFound: true, waitForCompletion: true, cancellationToken);
         }
 
-        async ValueTask putSpecification(ResourceName name, CancellationToken cancellationToken)
+        async ValueTask putSpecification(ResourceName name, JsonObject dto, CancellationToken cancellationToken)
         {
             var resourceKey = ResourceKey.From(resource, name, parents);
             var fileOperations = getCurrentFileOperations();
 
             var specificationOption = await getSpecification(resourceKey, fileOperations.ReadFile, cancellationToken);
 
-            await specificationOption.IterTask(async specification => await putSpecificationInApim(resourceKey, specification.Specification, specification.Contents, cancellationToken));
+            await specificationOption.IterTask(async specification => await putSpecificationInApim(resourceKey, dto, specification.Specification, specification.Contents, cancellationToken));
         }
     }
 
@@ -251,7 +251,7 @@ internal static partial class ResourceModule
 
             await putResourceInApim(resource, name, dto, parents, cancellationToken);
 
-            await putSpecification(resourceKey, cancellationToken);
+            await putSpecification(resourceKey, dto, cancellationToken);
         };
 
         async ValueTask setCurrentRevision(ResourceKey resourceKey, JsonObject dto, CancellationToken cancellationToken)
@@ -294,14 +294,14 @@ internal static partial class ResourceModule
             return GetWorkspaceApiRevisionFromDto(dtoJson);
         }
 
-        async ValueTask putSpecification(ResourceKey resourceKey, CancellationToken cancellationToken)
+        async ValueTask putSpecification(ResourceKey resourceKey, JsonObject dto, CancellationToken cancellationToken)
         {
             var fileOperations = getCurrentFileOperations();
 
             var specificationOption = await getSpecification(resourceKey, fileOperations.ReadFile, cancellationToken);
 
             await specificationOption.IterTask(async specification =>
-                await putSpecificationInApim(resourceKey, specification.Specification, specification.Contents, cancellationToken));
+                await putSpecificationInApim(resourceKey, dto, specification.Specification, specification.Contents, cancellationToken));
         }
 
         async ValueTask makeApiCurrent(ParentChain parents, ResourceName revisionedName, CancellationToken cancellationToken)


### PR DESCRIPTION
When publishing an API with a spec file, ApiOps performs two updates: first it PUTs the API DTO (including publisher overrides), then it PUTs the specification payload. The bug is that the spec PUT path was rebuilding its payload from a fresh APIM GET response, and that response can omit fields like translateRequiredQueryParameters. As a result, override values applied in the first PUT could be dropped in the second PUT, causing APIM to fall back to default behavior (e.g., required query params treated as path templates, leading to unexpected 404s instead of 400s).

The fix is to reuse the already-resolved publisher DTO as the base for spec publishing, then merge only spec-specific fields (format and value). This preserves override-controlled properties across both PUTs and keeps API behavior deterministic.


Closes #860 