### PR TITLE
Add support for OData API type

### DIFF
--- a/src/common/ApiSchema.cs
+++ b/src/common/ApiSchema.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace common;
@@ -52,5 +53,18 @@ public sealed record ApiSchemaDto
         [JsonPropertyName("value")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string? Value { get; init; }
+
+        [JsonPropertyName("odata")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string? OData { get; init; }
     }
+}
+
+public static class ApiSchemaExtensions
+{
+    public static bool IsODataSchema(this JsonObject schemaJson) =>
+        schemaJson.TryGetPropertyValue("properties", out var properties)
+        && properties is JsonObject propsObj
+        && propsObj.TryGetPropertyValue("contentType", out var contentType)
+        && contentType?.GetValue<string>() is "application/vnd.ms-azure-apim.odata.schema";
 }

--- a/src/common/ApiSpecification.cs
+++ b/src/common/ApiSpecification.cs
@@ -31,6 +31,12 @@ public abstract record ApiSpecification
         public static GraphQl Instance { get; } = new();
     }
 
+    public sealed record OData : ApiSpecification
+    {
+        private OData() { }
+        public static OData Instance { get; } = new();
+    }
+
     public sealed record Wadl : ApiSpecification
     {
         private Wadl() { }
@@ -90,6 +96,7 @@ public static partial class ResourceModule
 {
     private static readonly ImmutableArray<ApiSpecification> specifications = [
             ApiSpecification.GraphQl.Instance,
+            ApiSpecification.OData.Instance,
             ApiSpecification.Wsdl.Instance,
             ApiSpecification.Wadl.Instance,
             new ApiSpecification.OpenApi { Format = OpenApiFormat.Json.Instance, Version = OpenApiVersion.V2.Instance },
@@ -186,6 +193,7 @@ public static partial class ResourceModule
                 null => Option.Some(getDefaultSpecification()),
                 var value when "http".Equals(value, StringComparison.OrdinalIgnoreCase) => Option.Some(getDefaultSpecification()),
                 var value when "graphql".Equals(value, StringComparison.OrdinalIgnoreCase) => Option<ApiSpecification>.Some(ApiSpecification.GraphQl.Instance),
+                var value when "odata".Equals(value, StringComparison.OrdinalIgnoreCase) => Option<ApiSpecification>.Some(ApiSpecification.OData.Instance),
                 var value when "soap".Equals(value, StringComparison.OrdinalIgnoreCase) => Option<ApiSpecification>.Some(ApiSpecification.Wsdl.Instance),
                 _ => Option.None
             };
@@ -252,6 +260,8 @@ public static partial class ResourceModule
             {
                 case ApiSpecification.GraphQl:
                     return await getGraphQlSpecificationContents(resourceKey, cancellationToken);
+                case ApiSpecification.OData:
+                    return await getODataSpecificationContents(resourceKey, cancellationToken);
                 default:
                     // Get a link to download the specification
                     var exportUri = resource.GetUri(name, parents, serviceUri)
@@ -298,11 +308,21 @@ public static partial class ResourceModule
             }
         }
 
-        async ValueTask<Option<BinaryData>> getGraphQlSpecificationContents(ResourceKey resourceKey, CancellationToken cancellationToken)
+        ValueTask<Option<BinaryData>> getGraphQlSpecificationContents(ResourceKey resourceKey, CancellationToken cancellationToken) =>
+            getSchemaBasedSpecificationContents(resourceKey, schemaNameValue: "graphql", dto => dto.Properties.Document?.Value, cancellationToken);
+
+        ValueTask<Option<BinaryData>> getODataSpecificationContents(ResourceKey resourceKey, CancellationToken cancellationToken) =>
+            getSchemaBasedSpecificationContents(resourceKey, schemaNameValue: "default", dto => dto.Properties.Document?.OData, cancellationToken);
+
+        async ValueTask<Option<BinaryData>> getSchemaBasedSpecificationContents(
+            ResourceKey resourceKey,
+            string schemaNameValue,
+            Func<ApiSchemaDto, string?> documentSelector,
+            CancellationToken cancellationToken)
         {
             var (resource, name, parents) = (resourceKey.Resource, resourceKey.Name, resourceKey.Parents);
 
-            var schemaName = ResourceName.From("graphql").IfErrorThrow();
+            var schemaName = ResourceName.From(schemaNameValue).IfErrorThrow();
 
             IResourceWithDto schemaResource = resource switch
             {
@@ -312,12 +332,11 @@ public static partial class ResourceModule
             };
 
             var serializerOptions = schemaResource.SerializerOptions;
-
             var schemaAncestors = parents.Append(resource, name);
 
             return from dto in await getOptionalDto(schemaResource, schemaName, schemaAncestors, cancellationToken)
                    let result = from dtoObject in JsonNodeModule.To<ApiSchemaDto>(dto, serializerOptions)
-                                select dtoObject.Properties.Document?.Value
+                                select documentSelector(dtoObject)
                    from contents in result.ToOption()
                    where string.IsNullOrWhiteSpace(contents) is false
                    select BinaryData.FromString(contents);
@@ -404,6 +423,7 @@ public static partial class ResourceModule
                 ".json" or ".yaml" or ".yml" => from specification in await GetOpenApiSpecification(contents, file, cancellationToken)
                                                 select ((ApiSpecification)specification, contents),
                 ".graphql" => (ApiSpecification.GraphQl.Instance, contents),
+                ".edmx" => (ApiSpecification.OData.Instance, contents),
                 ".wadl" => (ApiSpecification.Wadl.Instance, contents),
                 ".wsdl" => (ApiSpecification.Wsdl.Instance, contents),
                 _ => Option.None,
@@ -436,6 +456,7 @@ public static partial class ResourceModule
         $"specification.{specification switch
         {
             ApiSpecification.GraphQl => "graphql",
+            ApiSpecification.OData => "edmx",
             ApiSpecification.Wsdl => "wsdl",
             ApiSpecification.Wadl => "wadl",
             ApiSpecification.OpenApi openApi when openApi.Format is OpenApiFormat.Json => "json",
@@ -560,6 +581,7 @@ public static partial class ResourceModule
                 ApiSpecification.Wadl wadlSpecification => putWadlSpecification(resourceKey, wadlSpecification, contents, cancellationToken),
                 ApiSpecification.Wsdl wsdlSpecification => putWsdlSpecification(resourceKey, wsdlSpecification, contents, cancellationToken),
                 ApiSpecification.GraphQl graphQlSpecification => putGraphQlSpecification(resourceKey, graphQlSpecification, contents, cancellationToken),
+                ApiSpecification.OData oDataSpecification => putODataSpecification(resourceKey, oDataSpecification, contents, cancellationToken),
                 _ => throw new InvalidOperationException($"Specification {specification} is not supported.")
             });
         };
@@ -691,6 +713,22 @@ public static partial class ResourceModule
             };
 
             await putResource(schemaResource, schemaName, schemaDto, schemaAncestors, cancellationToken);
+        }
+
+        async ValueTask putODataSpecification(ResourceKey resourceKey, ApiSpecification.OData specification, BinaryData contents, CancellationToken cancellationToken)
+        {
+            var dto = new JsonObject
+            {
+                ["properties"] = new JsonObject
+                {
+                    ["displayName"] = resourceKey.Name.ToString(),
+                    ["format"] = "odata",
+                    ["type"] = "odata",
+                    ["value"] = contents.ToString()
+                }
+            };
+
+            await putSpecificationDto(resourceKey, dto, useImportQueryParameter: true, cancellationToken);
         }
     }
 

--- a/src/common/Resource.Http.cs
+++ b/src/common/Resource.Http.cs
@@ -416,8 +416,11 @@ public static partial class ResourceModule
 
         return from content in await pipeline.GetContent(uri, cancellationToken)
                from json in JsonObjectModule.From(content, resource.SerializerOptions)
-               from formattedJson in resource.DeserializeToDtoJson(json)
-               select formattedJson;
+               // For OData API schemas, skip DTO normalization to preserve raw EDMX content
+               from dto in resource is ApiSchemaResource or WorkspaceApiSchemaResource && json.IsODataSchema()
+                   ? Result.Success(json)
+                   : resource.DeserializeToDtoJson(json)
+               select dto;
     }
 
     public static void ConfigureGetResourceDtoFromApim(IHostApplicationBuilder builder)

--- a/src/integration.tests/Api.cs
+++ b/src/integration.tests/Api.cs
@@ -16,7 +16,8 @@ internal enum ApiType
     Wadl,
     Wsdl,
     GraphQl,
-    WebSocket
+    WebSocket,
+    OData
 }
 
 internal static class ApiSpecificationModule
@@ -169,12 +170,7 @@ paths:
 
     public static string GetGraphQl(ResourceName apiName)
     {
-        var sanitizedName = new string([.. apiName.ToString() switch
-            {
-                [var first, .. var rest] when char.IsLetter(first) => ImmutableArray.Create([first, .. rest.Where(char.IsLetterOrDigit)]),
-                [var first, .. var rest] => [.. rest.Where(char.IsLetterOrDigit)],
-                _ => []
-            }]);
+        var sanitizedName = SanitizeNameForSchemaType(apiName);
 
         return $$"""
                 schema {
@@ -185,6 +181,41 @@ paths:
                 {{sanitizedName}}: String
                 }
                 """;
+    }
+
+    public static string GetOData(ResourceName apiName)
+    {
+        var sanitizedName = SanitizeNameForSchemaType(apiName);
+
+        return $$"""
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="{{sanitizedName}}" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="{{sanitizedName}}Entity">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false" />
+        <Property Name="Name" Type="Edm.String" />
+      </EntityType>
+      <EntityContainer Name="{{sanitizedName}}Container">
+        <EntitySet Name="{{sanitizedName}}Entities" EntityType="{{sanitizedName}}.{{sanitizedName}}Entity" />
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>
+""";
+    }
+
+    private static string SanitizeNameForSchemaType(ResourceName name)
+    {
+        return new string([.. name.ToString() switch
+        {
+            [var first, .. var rest] when char.IsLetter(first) => ImmutableArray.Create([first, .. rest.Where(char.IsLetterOrDigit)]),
+            [var first, .. var rest] => [.. rest.Where(char.IsLetterOrDigit)],
+            _ => []
+        }]);
     }
 }
 
@@ -234,6 +265,7 @@ internal sealed record ApiModel : ITestModel<ApiModel>
         var typeOption = Type switch
         {
             ApiType.GraphQl => Option.Some("graphql"),
+            ApiType.OData => Option.Some("odata"),
             ApiType.WebSocket => Option.Some("websocket"),
             _ => Option.None
         };
@@ -344,7 +376,7 @@ internal sealed record ApiModel : ITestModel<ApiModel>
         where apiType != ApiType.WebSocket // Skip websocket generation for now, unsupported in certain APIM SKUs
         from serviceUrl in apiType switch
         {
-            ApiType.Wadl or ApiType.Wsdl or ApiType.WebSocket => Generator.AbsoluteUri.Select(Option.Some),
+            ApiType.Wadl or ApiType.Wsdl or ApiType.WebSocket or ApiType.OData => Generator.AbsoluteUri.Select(Option.Some),
             _ => Generator.AbsoluteUri.OptionOf()
         }
         from versionSetKey in Gen.OneOfConst([.. models.OfType<VersionSetModel>()
@@ -433,6 +465,19 @@ internal sealed record ApiModel : ITestModel<ApiModel>
         else if (apiType is ApiType.GraphQl)
         {
             var specification = ApiSpecificationModule.GetGraphQl(rootApiName);
+
+            return Gen.Const(Option.Some(specification));
+        }
+        else if (apiType is ApiType.OData)
+        {
+            // We cannot reliably publish specifications for non-current API revisions.
+            if (apiName != rootApiName)
+            {
+                return Gen.Const(Option<string>.None());
+            }
+
+            var serviceUrl = serviceUriOption.IfNone(() => throw new InvalidOperationException("Service URL cannot be None for API type OData."));
+            var specification = ApiSpecificationModule.GetOData(rootApiName);
 
             return Gen.Const(Option.Some(specification));
         }

--- a/src/integration.tests/Apim.cs
+++ b/src/integration.tests/Apim.cs
@@ -224,6 +224,7 @@ internal static class ApimModule
                                                            ApiType.Wadl => ApiSpecification.Wadl.Instance,
                                                            ApiType.Wsdl => ApiSpecification.Wsdl.Instance,
                                                            ApiType.GraphQl => ApiSpecification.GraphQl.Instance,
+                                                           ApiType.OData => ApiSpecification.OData.Instance,
                                                            var type => throw new InvalidOperationException($"Cannot find specification for '{type}'.")
                                                        }
                                                        select (specification, contents);

--- a/src/integration.tests/Publisher.cs
+++ b/src/integration.tests/Publisher.cs
@@ -323,6 +323,7 @@ internal static class PublisherModule
                                                 ApiType.Wadl => ApiSpecification.Wadl.Instance,
                                                 ApiType.Wsdl => ApiSpecification.Wsdl.Instance,
                                                 ApiType.GraphQl => ApiSpecification.GraphQl.Instance,
+                                                ApiType.OData => ApiSpecification.OData.Instance,
                                                 var type => throw new InvalidOperationException($"Cannot find specification for '{type}'.")
                                             }
                                             select (specification, contents);


### PR DESCRIPTION
Adds support for OData API types across extractor and publisher flows.

This includes:
- Introducing `OData` as a first-class `ApiSpecification`
- Supporting `.edmx` specification files
- Handling OData schema extraction and publishing

Fixes:
- https://github.com/Azure/apiops/issues/419

## Changes

- Added `ApiSpecification.OData`
- Extended specification detection to include `odata`
- Added support for `.edmx` files in parsing and naming
- Implemented OData-specific handling for:
  - Specification retrieval
  - Specification publishing
- Introduced schema-based abstraction for GraphQL and OData
- Skipped DTO normalization for OData schemas to preserve raw EDMX

## Tests

- Extended integration tests to include `OData` API type
- Added EDMX specification generator for test scenarios
- Ensured OData APIs are covered in extractor and publisher validation flows

## Notes

A pull request already exists for OData support, but it is built on the v6 codebase (https://github.com/Azure/apiops/pull/798).