### PR TITLE
Preserve WSDL files during extractor artifact synchronization

### DIFF
--- a/tools/azdo_pipelines/run-extractor.yaml
+++ b/tools/azdo_pipelines/run-extractor.yaml
@@ -261,11 +261,11 @@ stages:
                 Write-Information "Synchronizing artifacts..."
                 $extractorArtifactsFolderPath = Join-Path "$(Pipeline.Workspace)" "artifacts-from-portal" ${{ parameters.API_MANAGEMENT_SERVICE_OUTPUT_FOLDER_PATH }}
                 if ("$(Agent.OS)" -like "*win*") {
-                    & robocopy "$extractorArtifactsFolderPath" "$artifactFolderPath" /zb /mir /mt
+                    & robocopy "$extractorArtifactsFolderPath" "$artifactFolderPath" /zb /mir /mt /XF *.wsdl
                     if ($LASTEXITCODE -gt 7) { throw "Setting $artifactFolderPath to contents of $extractorArtifactsFolderPath failed." }
                 }
                 else {
-                    & rsync --verbose --archive --delete --force --recursive "$extractorArtifactsFolderPath/" "$artifactFolderPath/"
+                    & rsync --verbose --archive --delete --force --recursive --exclude="*.wsdl" "$extractorArtifactsFolderPath/" "$artifactFolderPath/"
                     if ($LASTEXITCODE -ne 0) { throw "Setting $artifactFolderPath to contents of $extractorArtifactsFolderPath failed." }
                 }
 


### PR DESCRIPTION
## Summary
Prevents `.wsdl` files from being deleted during the artifact synchronization step in the Azure DevOps extractor pipeline.

## Problem
The extractor pipeline uses mirror mode (`robocopy /mir` and `rsync --delete`) to synchronize extracted artifacts to the repository. This causes WSDL files that exist in the repo but are not included in the current extraction to be deleted.

Starting with v7, WSDL files are no longer exported by the extractor. As a result, WSDL files for SOAP APIs must be placed manually in the repository and published from there. However, when running the extractor pipeline, these manually maintained WSDL files are unintentionally deleted during synchronization.

## Solution
Added exclusion flags for `.wsdl` files:
- **robocopy (Windows):** `/XF *.wsdl`
- **rsync (Linux/Mac):** `--exclude="*.wsdl"`

This preserves existing WSDL files in the destination while still allowing new WSDL files from the extraction to be copied.

## Changes
- `tools/azdo_pipelines/run-extractor.yaml`: Added WSDL exclusion to both robocopy and rsync commands