### PR TITLE
Add support for managed identity in backend authorization credentials

### DIFF
--- a/src/common/Backend.cs
+++ b/src/common/Backend.cs
@@ -160,9 +160,24 @@ public sealed record BackendDto
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public ImmutableDictionary<string, ImmutableArray<string>>? Header { get; init; }
 
+        [JsonPropertyName("managedIdentity")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public BackendManagedIdentityCredential? ManagedIdentity { get; init; }
+
         [JsonPropertyName("query")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public ImmutableDictionary<string, ImmutableArray<string>>? Query { get; init; }
+    }
+
+    public sealed record BackendManagedIdentityCredential
+    {
+        [JsonPropertyName("clientId")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string? ClientId { get; init; }
+
+        [JsonPropertyName("resource")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string? Resource { get; init; }
     }
 
     public sealed record BackendAuthorizationHeaderCredentials


### PR DESCRIPTION
## Summary

Adds managed identity credential support to the `BackendCredentialsContract` DTO, enabling extraction and publishing of backend managed identity authentication configuration.

## Context

The `BackendCredentialsContract` already supported `authorization`, `certificate`, `certificateIds`, `header`, and `query` credentials. Managed identity is an additional credential type supported by the Azure API Management REST API but was missing from the DTO.

> **Note:** The [official Microsoft REST API documentation](https://learn.microsoft.com/en-us/rest/api/apimanagement/backend/create-or-update?view=rest-apimanagement-2024-05-01&tabs=HTTP#backendcredentialscontract) does not explicitly document the `managedIdentity` property under `BackendCredentialsContract`, but the REST API does support it. This has been verified through manual testing of both extraction and publishing.

## Changes

- `src/common/Backend.cs`: Added `ManagedIdentity` property to `BackendCredentialsContract` and introduced the `BackendManagedIdentityCredential` record with `ClientId` and `Resource` properties.